### PR TITLE
Import FastHash hash function to util

### DIFF
--- a/src/Knet.Kudu.Client/Util/FastHash.cs
+++ b/src/Knet.Kudu.Client/Util/FastHash.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Knet.Kudu.Client.Util
+{
+    /// <summary>
+    /// FastHash is simple, robust, and efficient general-purpose hash function from Google.
+    /// Implementation is adapted from https://code.google.com/archive/p/fast-hash/
+    /// </summary>
+    public static class FastHash
+    {
+        /// <summary>
+        /// Compute 64-bit FastHash.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="seed">Seed to compute the hash.</param>
+        public static ulong Hash64(ReadOnlySpan<byte> source, ulong seed)
+        {
+            uint length = (uint)source.Length;
+            ulong kMultiplier = 0x880355f21e6d1965UL;
+            ulong h = seed ^ (length * kMultiplier);
+
+            ReadOnlySpan<ulong> data = MemoryMarshal.Cast<byte, ulong>(source);
+
+            foreach (ulong value in data)
+            {
+                h ^= FastHashMix(value);
+                h *= kMultiplier;
+            }
+
+            ReadOnlySpan<byte> data2 = source.Slice(data.Length * sizeof(ulong));
+            ulong v = 0;
+
+            switch (length & 7)
+            {
+                case 7: v ^= (ulong)data2[6] << 48; goto case 6;
+                case 6: v ^= (ulong)data2[5] << 40; goto case 5;
+                case 5: v ^= (ulong)data2[4] << 32; goto case 4;
+                case 4: v ^= (ulong)data2[3] << 24; goto case 3;
+                case 3: v ^= (ulong)data2[2] << 16; goto case 2;
+                case 2: v ^= (ulong)data2[1] << 8; goto case 1;
+                case 1:
+                    v ^= data2[0];
+                    h ^= FastHashMix(v);
+                    h *= kMultiplier;
+                    break;
+            }
+
+            return FastHashMix(h);
+        }
+
+        /// <summary>
+        /// Compute 32-bit FastHash.
+        /// </summary>
+        /// <param name="source">The data to hash.</param>
+        /// <param name="seed">Seed to compute the hash.</param>
+        public static uint Hash32(ReadOnlySpan<byte> source, uint seed)
+        {
+            // The following trick converts the 64-bit hashcode to Fermat
+            // residue, which shall retain information from both the higher
+            // and lower parts of hashcode.
+            ulong h = Hash64(source, seed);
+            return (uint)(h - (h >> 32));
+        }
+
+        /// <summary>
+        /// Compression function for Merkle-Damgard construction.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong FastHashMix(ulong h)
+        {
+            h ^= h >> 23;
+            h *= 0x2127599bf4325c37UL;
+            h ^= h >> 47;
+            return h;
+        }
+    }
+}

--- a/test/Knet.Kudu.Client.Tests/FastHashTests.cs
+++ b/test/Knet.Kudu.Client.Tests/FastHashTests.cs
@@ -1,0 +1,28 @@
+﻿using Knet.Kudu.Client.Util;
+using Xunit;
+
+namespace Knet.Kudu.Client.Tests
+{
+    public class FastHashTests
+    {
+        [Theory]
+        [InlineData("ab", 0, 17293172613997361769UL)]
+        [InlineData("abcdefg", 0, 10206404559164245992UL)]
+        [InlineData("quick brown fox", 42, 3757424404558187042UL)]
+        public void TestFastHash64(string data, ulong seed, ulong expectedHash)
+        {
+            ulong hash = FastHash.Hash64(data.ToUtf8ByteArray(), seed);
+            Assert.Equal(expectedHash, hash);
+        }
+
+        [Theory]
+        [InlineData("ab", 0, 2564147595U)]
+        [InlineData("abcdefg", 0, 1497700618U)]
+        [InlineData("quick brown fox", 42, 1676541068U)]
+        public void TestFastHash32(string data, uint seed, uint expectedHash)
+        {
+            uint hash = FastHash.Hash32(data.ToUtf8ByteArray(), seed);
+            Assert.Equal(expectedHash, hash);
+        }
+    }
+}


### PR DESCRIPTION
FastHash is a simple, robust, and efficient general purpose
hash function from Google.

It's fast, small in size and with least/no quality problems
as per smhasher and hence a good candidate for BlockBloomFilter.

Implementation has been ported straight from
https://code.google.com/archive/p/fast-hash/

Based on Kudu commit 5067abbdd2dc95eea74072dec1b07e3c0eb98423