### PR TITLE
Support default date value

### DIFF
--- a/src/Knet.Kudu.Client/AlterTableBuilder.cs
+++ b/src/Knet.Kudu.Client/AlterTableBuilder.cs
@@ -155,6 +155,9 @@ namespace Knet.Kudu.Client
                     "use RemoveDefault to clear a default value");
             }
 
+            var column = _table.Schema.GetColumn(name);
+            var defaultValue = KuduEncoder.EncodeDefaultValue(column.Type, newDefault);
+
             _request.AlterSchemaSteps.Add(new AlterTableRequestPB.Step
             {
                 Type = AlterTableRequestPB.StepType.AlterColumn,
@@ -163,7 +166,7 @@ namespace Knet.Kudu.Client
                     Delta = new ColumnSchemaDeltaPB
                     {
                         Name = name,
-                        DefaultValue = KuduEncoder.EncodeDefaultValue(newDefault)
+                        DefaultValue = defaultValue
                     }
                 }
             });

--- a/src/Knet.Kudu.Client/Util/KuduEncoder.cs
+++ b/src/Knet.Kudu.Client/Util/KuduEncoder.cs
@@ -181,35 +181,6 @@ namespace Knet.Kudu.Client.Util
             };
         }
 
-        /// <summary>
-        /// Serializes an object based on its C# type. Used for Alter Column
-        /// operations where the column's type is not available.
-        /// </summary>
-        /// <param name="value">The value to serialize.</param>
-        public static byte[] EncodeDefaultValue(object value)
-        {
-            return value switch
-            {
-                sbyte v => EncodeInt8(v),
-                byte v => EncodeInt8((sbyte)v),
-                short v => EncodeInt16(v),
-                ushort v => EncodeInt16((short)v),
-                int v => EncodeInt32(v),
-                uint v => EncodeInt32((int)v),
-                long v => EncodeInt64(v),
-                ulong v => EncodeInt64((long)v),
-                string v => EncodeString(v),
-                bool v => EncodeBool(v),
-                float v => EncodeFloat(v),
-                double v => EncodeDouble(v),
-                byte[] v => v,
-                DateTime v => EncodeDateTime(v),
-                // TODO: Add Date support here. For that, we need the data type.
-                decimal v => EncodeDefaultDecimal(v),
-                _ => throw new Exception($"Unsupported data type {value.GetType().Name}"),
-            };
-        }
-
         public static bool DecodeBool(ReadOnlySpan<byte> source) => source[0] > 0;
 
         public static sbyte DecodeInt8(ReadOnlySpan<byte> source) => (sbyte)source[0];

--- a/src/Knet.Kudu.Client/Util/KuduEncoder.cs
+++ b/src/Knet.Kudu.Client/Util/KuduEncoder.cs
@@ -168,6 +168,7 @@ namespace Knet.Kudu.Client.Util
                 KuduType.Int32 => EncodeInt32((int)value),
                 KuduType.Int64 => EncodeInt64((long)value),
                 KuduType.String => EncodeString((string)value),
+                KuduType.Varchar => EncodeString((string)value),
                 KuduType.Bool => EncodeBool((bool)value),
                 KuduType.Float => EncodeFloat((float)value),
                 KuduType.Double => EncodeDouble((double)value),


### PR DESCRIPTION
Remove the overload of EncodeDefaultValue that takes only an object. Without the Kudu type, it isn't possible to determine if a DateTime is for a UnixtimeMicros or Date column. This allows for specifying default Date values.

Also add a missing case for varchar.