### PR TITLE
Fix TLS authentication on .NET 5

### DIFF
--- a/src/Knet.Kudu.Client/Negotiate/KuduTlsAuthenticationStream.cs
+++ b/src/Knet.Kudu.Client/Negotiate/KuduTlsAuthenticationStream.cs
@@ -88,7 +88,7 @@ namespace Knet.Kudu.Client.Negotiate
 
         private int ReadHandshake(Memory<byte> buffer)
         {
-            var length = buffer.Length;
+            int length = Math.Min(buffer.Length, _result.TlsHandshake.Length);
             _result.TlsHandshake.AsSpan(_readPosition, length).CopyTo(buffer.Span);
             _readPosition += length;
             return length;


### PR DESCRIPTION
SslStream in .NET 5 supplies a larger buffer than expected.
Only copy the data we have, instead of trying to fill the entire buffer.