### PR TITLE
Fix decimal default encoding

### DIFF
--- a/src/Knet.Kudu.Client/AlterTableBuilder.cs
+++ b/src/Knet.Kudu.Client/AlterTableBuilder.cs
@@ -156,7 +156,7 @@ namespace Knet.Kudu.Client
             }
 
             var column = _table.Schema.GetColumn(name);
-            var defaultValue = KuduEncoder.EncodeDefaultValue(column.Type, newDefault);
+            var defaultValue = KuduEncoder.EncodeDefaultValue(column, newDefault);
 
             _request.AlterSchemaSteps.Add(new AlterTableRequestPB.Step
             {

--- a/src/Knet.Kudu.Client/AlterTableBuilder.cs
+++ b/src/Knet.Kudu.Client/AlterTableBuilder.cs
@@ -59,9 +59,9 @@ namespace Knet.Kudu.Client
             var columnBuilder = new ColumnBuilder(name, type);
             configure?.Invoke(columnBuilder);
 
-            ColumnSchemaPB schema = columnBuilder;
+            var schema = columnBuilder.Build();
 
-            if (!schema.IsNullable && schema.ReadDefaultValue == null)
+            if (!schema.IsNullable && schema.DefaultValue == null)
                 throw new ArgumentException("A new non-null column must have a default value");
 
             if (schema.IsKey)
@@ -72,7 +72,7 @@ namespace Knet.Kudu.Client
                 Type = AlterTableRequestPB.StepType.AddColumn,
                 AddColumn = new AlterTableRequestPB.AddColumn
                 {
-                    Schema = schema
+                    Schema = schema.ToColumnSchemaPb()
                 }
             });
 

--- a/src/Knet.Kudu.Client/ColumnSchema.cs
+++ b/src/Knet.Kudu.Client/ColumnSchema.cs
@@ -153,5 +153,16 @@ namespace Knet.Kudu.Client
                     return "";
             }
         }
+
+        public static ColumnTypeAttributes NewDecimalAttributes(
+            int precision, int scale)
+        {
+            return new ColumnTypeAttributes(precision, scale, null);
+        }
+
+        public static ColumnTypeAttributes NewVarcharAttributes(int length)
+        {
+            return new ColumnTypeAttributes(null, null, length);
+        }
     }
 }

--- a/src/Knet.Kudu.Client/TableBuilder.cs
+++ b/src/Knet.Kudu.Client/TableBuilder.cs
@@ -111,7 +111,8 @@ namespace Knet.Kudu.Client
         {
             var builder = new ColumnBuilder(name, type);
             configure?.Invoke(builder);
-            CreateTableRequest.Schema.Columns.Add(builder);
+            var columnSchemaPb = builder.Build().ToColumnSchemaPb();
+            CreateTableRequest.Schema.Columns.Add(columnSchemaPb);
             return this;
         }
 

--- a/src/Knet.Kudu.Client/Util/DecimalUtil.cs
+++ b/src/Knet.Kudu.Client/Util/DecimalUtil.cs
@@ -220,12 +220,6 @@ namespace Knet.Kudu.Client.Util
             return KuduInt128.PowerOf10(precision) - 1;
         }
 
-        public static int GetScale(decimal value)
-        {
-            var dec = new DecimalAccessor(value);
-            return (int)dec.Scale;
-        }
-
         public static decimal SetScale(decimal value, int scale)
         {
             var dec = new DecimalAccessor(value) { Scale = (uint)scale };

--- a/src/Knet.Kudu.Client/Util/ProtobufHelper.cs
+++ b/src/Knet.Kudu.Client/Util/ProtobufHelper.cs
@@ -87,6 +87,28 @@ namespace Knet.Kudu.Client.Util
             return pb;
         }
 
+        public static ColumnSchemaPB ToColumnSchemaPb(this ColumnSchema columnSchema)
+        {
+            var defaultValue = columnSchema.DefaultValue;
+            var encodedDefaultValue = defaultValue != null
+                ? KuduEncoder.EncodeDefaultValue(columnSchema.Type, columnSchema.DefaultValue)
+                : null;
+
+            return new ColumnSchemaPB
+            {
+                Name = columnSchema.Name,
+                Type = (DataTypePB)columnSchema.Type,
+                IsKey = columnSchema.IsKey,
+                IsNullable = columnSchema.IsNullable,
+                ReadDefaultValue = encodedDefaultValue,
+                CfileBlockSize = columnSchema.DesiredBlockSize,
+                Encoding = (EncodingTypePB)columnSchema.Encoding,
+                Compression = (CompressionTypePB)columnSchema.Compression,
+                TypeAttributes = columnSchema.TypeAttributes.ToTypeAttributesPb(),
+                Comment = columnSchema.Comment
+            };
+        }
+
         public static PartitionSchema CreatePartitionSchema(
             PartitionSchemaPB partitionSchemaPb, KuduSchema schema)
         {

--- a/src/Knet.Kudu.Client/Util/ProtobufHelper.cs
+++ b/src/Knet.Kudu.Client/Util/ProtobufHelper.cs
@@ -91,7 +91,7 @@ namespace Knet.Kudu.Client.Util
         {
             var defaultValue = columnSchema.DefaultValue;
             var encodedDefaultValue = defaultValue != null
-                ? KuduEncoder.EncodeDefaultValue(columnSchema.Type, columnSchema.DefaultValue)
+                ? KuduEncoder.EncodeDefaultValue(columnSchema, columnSchema.DefaultValue)
                 : null;
 
             return new ColumnSchemaPB


### PR DESCRIPTION
Fix a bug where a default value for a decimal column would be encoded incorrectly if the value's scale was different from the column's scale.

It also includes a refactor to ColumnBuilder to make the fix easier.

| Precision/Scale | Input                   | Incorrect Output        |
| --------------- | ----------------------- | ----------------------- |
| (4, 2)          | 12.1                    | 1.21                    |
| (12, 4)         | 123456.123              | 12345.6123              |
| (38, 8)         | 123456789123456789.1234 | 12345678912345.67891234 |