### PR TITLE
KUDU-2162 Expose stats about scan filters

### DIFF
--- a/src/Knet.Kudu.Client/KuduScanEnumerator.cs
+++ b/src/Knet.Kudu.Client/KuduScanEnumerator.cs
@@ -57,6 +57,8 @@ namespace Knet.Kudu.Client
 
         public T Current { get; private set; }
 
+        public ResourceMetrics ResourceMetrics { get; }
+
         public KuduScanEnumerator(
             ILogger logger,
             KuduClient client,
@@ -125,6 +127,7 @@ namespace Knet.Kudu.Client
             SnapshotTimestamp = htTimestamp;
             _lastPrimaryKey = Array.Empty<byte>();
             _cancellationToken = cancellationToken;
+            ResourceMetrics = new ResourceMetrics();
             // TODO: Register cancellation callback and cancel the scan.
 
             // Map the column names to actual columns in the table schema.
@@ -317,6 +320,9 @@ namespace Knet.Kudu.Client
             _numRowsReturned += response.NumRows;
             Current = response.Data;
 
+            if (response.ResourceMetricsPb != null)
+                ResourceMetrics.Update(response.ResourceMetricsPb);
+
             if (!response.HasMoreResults || response.ScannerId == null)
             {
                 ScanFinished();
@@ -370,6 +376,9 @@ namespace Knet.Kudu.Client
 
             _numRowsReturned += response.NumRows;
             Current = response.Data;
+
+            if (response.ResourceMetricsPb != null)
+                ResourceMetrics.Update(response.ResourceMetricsPb);
 
             if (!response.HasMoreResults)
             {

--- a/src/Knet.Kudu.Client/Requests/ScanRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/ScanRequest.cs
@@ -72,6 +72,9 @@ namespace Knet.Kudu.Client.Requests
             {
                 var newRequest = _scanRequestPb.NewScanRequest;
 
+                // Set tabletId here, as we don't know what tablet the request is
+                // going to until GetTabletAsync() is called and that tablet is
+                // set on this RPC.
                 newRequest.TabletId = Tablet.TabletId.ToUtf8ByteArray();
 
                 if (AuthzToken != null)
@@ -137,7 +140,8 @@ namespace Knet.Kudu.Client.Requests
                     _responsePB.HasMoreResults,
                     _responsePB.ShouldSerializeSnapTimestamp() ? (long)_responsePB.SnapTimestamp : KuduClient.NoTimestamp,
                     _responsePB.ShouldSerializePropagatedTimestamp() ? (long)_responsePB.PropagatedTimestamp : KuduClient.NoTimestamp,
-                    _responsePB.LastPrimaryKey);
+                    _responsePB.LastPrimaryKey,
+                    _responsePB.ResourceMetrics);
             }
         }
 

--- a/src/Knet.Kudu.Client/ResourceMetrics.cs
+++ b/src/Knet.Kudu.Client/ResourceMetrics.cs
@@ -1,0 +1,57 @@
+﻿using Knet.Kudu.Client.Protocol.Tserver;
+
+namespace Knet.Kudu.Client
+{
+    public class ResourceMetrics
+    {
+        /// <summary>
+        /// Number of bytes that were read because of a block cache miss.
+        /// </summary>
+        public long CfileCacheMissBytes { get; private set; }
+
+        /// <summary>
+        /// Number of bytes that were read from the block cache because of a hit.
+        /// </summary>
+        public long CfileCacheHitBytes { get; private set; }
+
+        /// <summary>
+        /// Number of bytes read from disk (or cache) by the scanner.
+        /// </summary>
+        public long BytesRead { get; private set; }
+
+        /// <summary>
+        /// Total time taken between scan rpc requests being accepted and when they
+        /// were handled in nanoseconds for this scanner.
+        /// </summary>
+        public long QueueDurationNanos { get; private set; }
+
+        /// <summary>
+        /// Total time taken for all scan rpc requests to complete in nanoseconds
+        /// for this scanner.
+        /// </summary>
+        public long TotalDurationNanos { get; private set; }
+
+        /// <summary>
+        /// Total elapsed CPU user time in nanoseconds for all scan rpc requests
+        /// for this scanner.
+        /// </summary>
+        public long CpuUserNanos { get; private set; }
+
+        /// <summary>
+        /// Total elapsed CPU system time in nanoseconds for all scan rpc requests
+        /// for this scanner.
+        /// </summary>
+        public long CpuSystemNanos { get; private set; }
+
+        internal void Update(ResourceMetricsPB resourceMetricsPb)
+        {
+            CfileCacheMissBytes += resourceMetricsPb.CfileCacheMissBytes;
+            CfileCacheHitBytes += resourceMetricsPb.CfileCacheHitBytes;
+            BytesRead += resourceMetricsPb.BytesRead;
+            QueueDurationNanos += resourceMetricsPb.QueueDurationNanos;
+            TotalDurationNanos += resourceMetricsPb.TotalDurationNanos;
+            CpuUserNanos += resourceMetricsPb.CpuUserNanos;
+            CpuSystemNanos += resourceMetricsPb.CpuSystemNanos;
+        }
+    }
+}

--- a/src/Knet.Kudu.Client/Scanner/ScanResponse.cs
+++ b/src/Knet.Kudu.Client/Scanner/ScanResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace Knet.Kudu.Client.Scanner
+﻿using Knet.Kudu.Client.Protocol.Tserver;
+
+namespace Knet.Kudu.Client.Scanner
 {
     /// <summary>
     /// Helper object that contains all the info sent by a TS after a Scan request.
@@ -51,6 +53,8 @@
         /// </summary>
         public byte[] LastPrimaryKey { get; }
 
+        public ResourceMetricsPB ResourceMetricsPb { get; }
+
         public ScanResponse(
             byte[] scannerId,
             T data,
@@ -58,7 +62,8 @@
             bool hasMoreResults,
             long scanTimestamp,
             long propagatedTimestamp,
-            byte[] lastPrimaryKey)
+            byte[] lastPrimaryKey,
+            ResourceMetricsPB resourceMetricsPb)
         {
             ScannerId = scannerId;
             Data = data;
@@ -67,6 +72,7 @@
             ScanTimestamp = scanTimestamp;
             PropagatedTimestamp = propagatedTimestamp;
             LastPrimaryKey = lastPrimaryKey;
+            ResourceMetricsPb = resourceMetricsPb;
         }
     }
 }

--- a/test/Knet.Kudu.Client.FunctionalTests/Util/ClientTestUtil.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/Util/ClientTestUtil.cs
@@ -95,5 +95,15 @@ namespace Knet.Kudu.Client.FunctionalTests.Util
 
             return rows;
         }
+
+        public static async Task<int> CountRowsInScanAsync(KuduScanEnumerator<ResultSet> scanner)
+        {
+            var rows = 0;
+
+            while (await scanner.MoveNextAsync())
+                rows += scanner.Current.Count;
+
+            return rows;
+        }
     }
 }


### PR DESCRIPTION
This patch adds the following resource metrics to scanners.
- bytes read, from disk or cache
- scan rpc wait and total duration scanner was open in nanoseconds
- cpu time and system time in nanoseconds