### PR TITLE
Place newest framework first

### DIFF
--- a/src/Knet.Kudu.Client/Knet.Kudu.Client.csproj
+++ b/src/Knet.Kudu.Client/Knet.Kudu.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0;netstandard2.1;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>CS1591</NoWarn>


### PR DESCRIPTION
VS Code doesn't support multi-targeted projects; it just loads the first framework it finds. This leads to VS Code displaying tons of errors, and breaking intellisense where the errors occur. This is purely visual; the project still builds and runs fine.

Place the newest framework first, so VS Code uses it and doesn't display errors.