### PR TITLE
Prefer tservers in the same location when multiple are local

### DIFF
--- a/src/Knet.Kudu.Client/Connection/ServerInfo.cs
+++ b/src/Knet.Kudu.Client/Connection/ServerInfo.cs
@@ -31,6 +31,8 @@ namespace Knet.Kudu.Client.Connection
             IsLocal = isLocal;
         }
 
+        public bool HasLocation => !string.IsNullOrEmpty(Location);
+
         /// <summary>
         /// Returns true if the server is in the same location as the given location.
         /// </summary>

--- a/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
+++ b/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
@@ -69,15 +69,15 @@ namespace Knet.Kudu.Client.Connection
             byte sameLocationIndex = 0;
             bool missingLocation = string.IsNullOrEmpty(location);
 
-            foreach (ServerInfo e in servers)
+            foreach (var serverInfo in servers)
             {
-                bool serverInSameLocation = e.InSameLocation(location);
+                bool serverInSameLocation = serverInfo.InSameLocation(location);
 
                 // Only consider a server "local" if we're in the same location, or if
                 // there is missing location info.
-                if (missingLocation || !e.HasLocation || serverInSameLocation)
+                if (missingLocation || !serverInfo.HasLocation || serverInSameLocation)
                 {
-                    if (e.IsLocal)
+                    if (serverInfo.IsLocal)
                         localServers[localIndex++] = index;
                 }
 
@@ -85,7 +85,7 @@ namespace Knet.Kudu.Client.Connection
                     serversInSameLocation[sameLocationIndex++] = index;
 
                 if (index == randomIndex)
-                    result = e;
+                    result = serverInfo;
 
                 index++;
             }

--- a/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
+++ b/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
@@ -52,9 +52,10 @@ namespace Knet.Kudu.Client.Connection
         public ServerInfo GetClosestServerInfo(string location = null)
         {
             // This method returns
-            // 1. a randomly picked server among local servers, if there is a local server, or
-            // 2. a randomly picked server in the same location, if there is a server in the
-            //    same location, or, finally,
+            // 1. a randomly picked server among local servers, if there is one based
+            //    on IP and assigned location, or
+            // 2. a randomly picked server in the same assigned location, if there is a
+            //    server in the same location, or, finally,
             // 3. a randomly picked server among all tablet servers.
 
             var servers = _servers;
@@ -66,13 +67,21 @@ namespace Knet.Kudu.Client.Connection
             byte index = 0;
             byte localIndex = 0;
             byte sameLocationIndex = 0;
+            bool missingLocation = string.IsNullOrEmpty(location);
 
             foreach (ServerInfo e in servers)
             {
-                if (e.IsLocal)
-                    localServers[localIndex++] = index;
+                bool serverInSameLocation = e.InSameLocation(location);
 
-                if (e.InSameLocation(location))
+                // Only consider a server "local" if we're in the same location, or if
+                // there is missing location info.
+                if (missingLocation || !e.HasLocation || serverInSameLocation)
+                {
+                    if (e.IsLocal)
+                        localServers[localIndex++] = index;
+                }
+
+                if (serverInSameLocation)
                     serversInSameLocation[sameLocationIndex++] = index;
 
                 if (index == randomIndex)

--- a/test/Knet.Kudu.Client.Tests/ServerInfoCacheTests.cs
+++ b/test/Knet.Kudu.Client.Tests/ServerInfoCacheTests.cs
@@ -7,48 +7,50 @@ namespace Knet.Kudu.Client.Tests
 {
     public class ServerInfoCacheTests
     {
-        private static readonly string ClientLocation = "/fake-client";
-        private static readonly string Location = "/fake-noclient";
-        private static readonly string NoLocation = "";
-        private static readonly string[] Uuids = { "uuid-0", "uuid-1", "uuid-2" };
+        private static readonly string _clientLocation = "/fake-client";
+        private static readonly string _location = "/fake-noclient";
+        private static readonly string _noLocation = "";
+        private static readonly string[] _uuids = { "uuid-0", "uuid-1", "uuid-2" };
 
         [Fact]
-        public void LocalReplicaNotSameLocation()
+        public void TestLocalReplica()
         {
-            // Tablet with no replicas in the same location as the client.
-            var cache = GetCache(0, 0, -1);
+            {
+                // Let's examine a tablet where the first UUID is local to the client,
+                // but no UUID is in the same location.
+                var cache = GetCache(0, 0, -1);
 
-            // No location for the client.
-            Assert.Equal(Uuids[0], cache.GetClosestServerInfo(NoLocation).Uuid);
+                // If the client has no location, we should pick the local server.
+                Assert.Equal(_uuids[0], cache.GetClosestServerInfo(_noLocation).Uuid);
 
-            // Client with location.
-            Assert.Equal(Uuids[0], cache.GetClosestServerInfo(ClientLocation).Uuid);
-        }
+                // NOTE: if the client did have a location, because the test replicas are
+                // assigned a different default location, they aren't considered local,
+                // so we would select one at random.
+            }
+            {
+                // Let's examine a tablet where the first UUID is local to the client,
+                // and the second is in the same location.
+                var cache = GetCache(0, 0, 1);
 
-        [Fact]
-        public void NonLocalReplicaSameLocation()
-        {
-            // Tablet with a non-local replica in the same location as the client.
-            var cache = GetCache(0, 0, 1);
+                // If the client has no location, we should pick the local server.
+                Assert.Equal(_uuids[0], cache.GetClosestServerInfo(_noLocation).Uuid);
 
-            // No location for the client.
-            Assert.Equal(Uuids[0], cache.GetClosestServerInfo(NoLocation).Uuid);
+                // If the client does have a location, we should pick the one in the same
+                // location.
+                Assert.Equal(_uuids[1], cache.GetClosestServerInfo(_clientLocation).Uuid);
+            }
+            {
+                // Let's examine a tablet where the first UUID is local to the client and
+                // is also in the same location.
+                var cache = GetCache(0, 0, 0);
 
-            // Client with location. The local replica should be chosen.
-            Assert.Equal(Uuids[0], cache.GetClosestServerInfo(ClientLocation).Uuid);
-        }
+                // If the client has no location, we should pick the local server.
+                Assert.Equal(_uuids[0], cache.GetClosestServerInfo(_noLocation).Uuid);
 
-        [Fact]
-        public void LocalReplicaSameLocation()
-        {
-            // Tablet with a local replica in the same location as the client.
-            var cache = GetCache(0, 0, 0);
-
-            // No location for the client.
-            Assert.Equal(Uuids[0], cache.GetClosestServerInfo(NoLocation).Uuid);
-
-            // Client with location. The local replica should be chosen.
-            Assert.Equal(Uuids[0], cache.GetClosestServerInfo(ClientLocation).Uuid);
+                // If the client does have a location, we should pick the one in the same
+                // location.
+                Assert.Equal(_uuids[0], cache.GetClosestServerInfo(_clientLocation).Uuid);
+            }
         }
 
         [Fact]
@@ -57,36 +59,47 @@ namespace Knet.Kudu.Client.Tests
             var cache = GetCache(0, -1, -1);
 
             // We just care about getting one back.
-            var info = cache.GetClosestServerInfo(ClientLocation);
+            var info = cache.GetClosestServerInfo(_clientLocation);
             Assert.NotNull(info.Uuid);
         }
 
         [Fact]
-        public void LocalReplica()
+        public void TestReplicaSelection()
         {
-            var cache = GetCache(0, 1, 2);
+            {
+                var cache = GetCache(0, 1, 2);
 
-            // LEADER_ONLY picks the leader even if there's a local replica.
-            Assert.Equal(Uuids[0],
-                cache.GetServerInfo(ReplicaSelection.LeaderOnly, ClientLocation).Uuid);
+                // LEADER_ONLY picks the leader even if there's a local replica.
+                Assert.Equal(_uuids[0],
+                    cache.GetServerInfo(ReplicaSelection.LeaderOnly, _clientLocation).Uuid);
 
-            // CLOSEST_REPLICA picks the local replica even if there's a replica in the same location.
-            Assert.Equal(Uuids[1],
-                cache.GetServerInfo(ReplicaSelection.ClosestReplica, ClientLocation).Uuid);
-        }
+                // Since there are locations assigned, CLOSEST_REPLICA picks the replica
+                // in the same location, even if there's a local one.
+                Assert.Equal(_uuids[2],
+                    cache.GetServerInfo(ReplicaSelection.ClosestReplica, _clientLocation).Uuid);
+            }
+            {
+                var cache = GetCache(0, -1, 1);
 
-        [Fact]
-        public void NoLocalReplica()
-        {
-            var cache = GetCache(0, -1, 1);
+                // LEADER_ONLY picks the leader even if there's a replica with the same location.
+                Assert.Equal(_uuids[0],
+                    cache.GetServerInfo(ReplicaSelection.LeaderOnly, _clientLocation).Uuid);
 
-            // LEADER_ONLY picks the leader even if there's a replica with the same location.
-            Assert.Equal(Uuids[0],
-                cache.GetServerInfo(ReplicaSelection.LeaderOnly, ClientLocation).Uuid);
+                // CLOSEST_REPLICA picks the replica in the same location.
+                Assert.Equal(_uuids[1],
+                    cache.GetServerInfo(ReplicaSelection.ClosestReplica, _clientLocation).Uuid);
+            }
+            {
+                var cache = GetCache(0, 1, -1);
 
-            // CLOSEST_REPLICA picks the replica in the same location.
-            Assert.Equal(Uuids[1],
-                cache.GetServerInfo(ReplicaSelection.ClosestReplica, ClientLocation).Uuid);
+                // LEADER_ONLY picks the leader even if there's a local replica.
+                Assert.Equal(_uuids[0],
+                    cache.GetServerInfo(ReplicaSelection.LeaderOnly, _clientLocation).Uuid);
+
+                // NOTE: the test replicas are assigned a default location. So, even if
+                // there are local replicas, because they are in different locations than
+                // the client, with CLOSEST_REPLICA, a replica is chosen at random.y
+            }
         }
 
         [Fact]
@@ -107,15 +120,19 @@ namespace Knet.Kudu.Client.Tests
 
         private void VerifyGetReplicaSelectedServerInfoDeterminism(ServerInfoCache cache)
         {
-            string init = cache.GetClosestServerInfo(ClientLocation).Uuid;
+            string init = cache.GetClosestServerInfo(_clientLocation).Uuid;
             for (int i = 0; i < 10; i++)
             {
-                string next = cache.GetClosestServerInfo(ClientLocation).Uuid;
+                string next = cache.GetClosestServerInfo(_clientLocation).Uuid;
 
                 Assert.Equal(init, next);
             }
         }
 
+        /// <summary>
+        /// Returns a three-replica remote tablet that considers the given indices of
+        /// replicas to be leader, local to the client, and in the same location.
+        /// </summary>
         private ServerInfoCache GetCache(
             int leaderIndex,
             int localReplicaIndex,
@@ -123,12 +140,12 @@ namespace Knet.Kudu.Client.Tests
         {
             var servers = new List<ServerInfo>();
 
-            for (int i = 0; i < 2; i++)
+            for (int i = 0; i < 3; i++)
             {
-                var uuid = Uuids[i];
+                var uuid = _uuids[i];
                 var port = 1000 + i;
                 var hostPort = new HostAndPort("host", port);
-                var location = i == sameLocationReplicaIndex ? ClientLocation : Location;
+                var location = i == sameLocationReplicaIndex ? _clientLocation : _location;
                 var local = i == localReplicaIndex;
                 var endpoint = i == localReplicaIndex ?
                     new IPEndPoint(IPAddress.Parse("127.0.0.1"), port) :

--- a/test/Knet.Kudu.Client.Tests/ServerInfoCacheTests.cs
+++ b/test/Knet.Kudu.Client.Tests/ServerInfoCacheTests.cs
@@ -139,10 +139,11 @@ namespace Knet.Kudu.Client.Tests
             int sameLocationReplicaIndex)
         {
             var servers = new List<ServerInfo>();
+            var uuids = _uuids;
 
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < uuids.Length; i++)
             {
-                var uuid = _uuids[i];
+                var uuid = uuids[i];
                 var port = 1000 + i;
                 var hostPort = new HostAndPort("host", port);
                 var location = i == sameLocationReplicaIndex ? _clientLocation : _location;


### PR DESCRIPTION
If multiple servers are colocated with a client, and the servers are
assigned different locations, those locations should be honored when
picking tablet servers.