### PR TITLE
Make empty projection scans consistent

### DIFF
--- a/src/Knet.Kudu.Client/ColumnarResultSet.cs
+++ b/src/Knet.Kudu.Client/ColumnarResultSet.cs
@@ -84,6 +84,21 @@ namespace Knet.Kudu.Client
         internal int GetNonNullBitmapOffset(int columnIndex) =>
             _nonNullBitmapSidecarOffsets[columnIndex];
 
+        private ReadOnlySpan<byte> GetData()
+        {
+            var sidecars = _sidecars;
+
+            if (sidecars is null)
+            {
+                // Empty projection.
+                return default;
+            }
+            else
+            {
+                return sidecars.Span;
+            }
+        }
+
         public override string ToString() => $"{Count} rows";
 
         public Enumerator GetEnumerator() => new Enumerator(this);
@@ -99,18 +114,8 @@ namespace Knet.Kudu.Client
             {
                 _resultSet = resultSet;
                 _index = -1;
-
-                if (resultSet._sidecars is null)
-                {
-                    // Empty projection.
-                    _data = default;
-                    _numRows = 0;
-                }
-                else
-                {
-                    _data = resultSet._sidecars.Span;
-                    _numRows = (int)resultSet.Count;
-                }
+                _numRows = (int)resultSet.Count;
+                _data = resultSet.GetData();
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/Knet.Kudu.Client.FunctionalTests/RowResultTests.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/RowResultTests.cs
@@ -161,5 +161,49 @@ namespace Knet.Kudu.Client.FunctionalTests
 
             Assert.Equal(numRows, currentRow);
         }
+
+        [SkippableFact]
+        public async Task TestEmptyProjection()
+        {
+            await using var miniCluster = await new MiniKuduClusterBuilder().BuildAsync();
+            await using var client = miniCluster.CreateClient();
+            await using var session = client.NewSession();
+
+            var builder = ClientTestUtil.CreateAllTypesSchema()
+                .SetTableName(nameof(TestEmptyProjection))
+                .CreateBasicRangePartition();
+
+            var table = await client.CreateTableAsync(builder);
+
+            int numRows = 5;
+            int currentRow = 0;
+            for (int i = 0; i < numRows; i++)
+            {
+                var insert = ClientTestUtil.CreateAllTypesInsert(table, i);
+                await session.EnqueueAsync(insert);
+            }
+
+            await session.FlushAsync();
+
+            var scanner = client.NewScanBuilder<ResultSet>(table)
+                .SetEmptyProjection()
+                .Build();
+
+            await foreach (var resultSet in scanner)
+            {
+                Assert.Empty(resultSet.Schema.Columns);
+                CheckResults(resultSet);
+            }
+
+            void CheckResults(ResultSet resultSet)
+            {
+                foreach (var row in resultSet)
+                {
+                    currentRow++;
+                }
+            }
+
+            Assert.Equal(numRows, currentRow);
+        }
     }
 }


### PR DESCRIPTION
Allow result sets to be iterated for empty projections (like the Java client)