### PR TITLE
Support resolving one master address to multiple addresses

### DIFF
--- a/src/Knet.Kudu.Client/Connection/IKuduConnectionFactory.cs
+++ b/src/Knet.Kudu.Client/Connection/IKuduConnectionFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -5,8 +6,13 @@ namespace Knet.Kudu.Client.Connection
 {
     public interface IKuduConnectionFactory
     {
-        Task<KuduConnection> ConnectAsync(ServerInfo serverInfo, CancellationToken cancellationToken = default);
+        Task<KuduConnection> ConnectAsync(
+            ServerInfo serverInfo, CancellationToken cancellationToken = default);
 
-        Task<ServerInfo> GetServerInfoAsync(string uuid, string location, HostAndPort hostPort);
+        Task<List<ServerInfo>> GetMasterServerInfoAsync(
+            HostAndPort hostPort, CancellationToken cancellationToken = default);
+
+        Task<ServerInfo> GetTabletServerInfoAsync(
+            HostAndPort hostPort, string uuid, string location, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Knet.Kudu.Client/Connection/KuduConnectionFactoryExtensions.cs
+++ b/src/Knet.Kudu.Client/Connection/KuduConnectionFactoryExtensions.cs
@@ -27,7 +27,7 @@ namespace Knet.Kudu.Client.Connection
             // based on some kind of policy. For now just use the first always.
             var hostPort = addresses[0].ToHostAndPort();
 
-            return connectionFactory.GetServerInfoAsync(uuid, location, hostPort);
+            return connectionFactory.GetTabletServerInfoAsync(hostPort, uuid, location);
         }
 
         public static async Task<List<RemoteTablet>> GetTabletsAsync(

--- a/src/Knet.Kudu.Client/Exceptions/NoLeaderFoundException.cs
+++ b/src/Knet.Kudu.Client/Exceptions/NoLeaderFoundException.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Knet.Kudu.Client.Connection;
 
 namespace Knet.Kudu.Client.Exceptions
 {
@@ -11,30 +10,19 @@ namespace Knet.Kudu.Client.Exceptions
     /// </summary>
     public class NoLeaderFoundException : RecoverableException
     {
-        public NoLeaderFoundException(
-            IReadOnlyList<HostAndPort> masterAddresses,
-            Dictionary<HostAndPort, Exception> results)
-            : base(
-                  KuduStatus.NetworkError(GetMessage(masterAddresses, results)),
-                  new AggregateException(results.Values))
+        public NoLeaderFoundException(IEnumerable<string> results, Exception innerException)
+            : base(KuduStatus.NetworkError(GetMessage(results)), innerException)
         {
         }
 
-        private static string GetMessage(
-            IReadOnlyList<HostAndPort> masterAddresses,
-            Dictionary<HostAndPort, Exception> results)
+        private static string GetMessage(IEnumerable<string> results)
         {
             var sb = new StringBuilder("Unable to find master leader:");
 
-            foreach (var address in masterAddresses)
+            foreach (var result in results)
             {
                 sb.AppendLine();
-                sb.Append($"\t{address} => ");
-
-                if (results.TryGetValue(address, out var exception))
-                    sb.Append(exception.Message);
-                else
-                    sb.Append("Not the leader");
+                sb.Append($"\t{result}");
             }
 
             return sb.ToString();

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -977,7 +977,7 @@ namespace Knet.Kudu.Client
         /// Locate the leader master and retrieve the cluster information.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        public async Task<ServerInfo> ConnectToClusterAsync(CancellationToken cancellationToken)
+        private async Task<ServerInfo> ConnectToClusterAsync(CancellationToken cancellationToken)
         {
             var masterAddresses = _options.MasterAddresses;
             var tasks = new Dictionary<Task<ConnectToMasterResponse>, HostAndPort>(masterAddresses.Count);

--- a/src/Knet.Kudu.Client/Util/Extensions.cs
+++ b/src/Knet.Kudu.Client/Util/Extensions.cs
@@ -30,15 +30,6 @@ namespace Knet.Kudu.Client.Util
         public static bool SequenceEqual<T>(this T[] array, ReadOnlySpan<T> other)
             where T : IEquatable<T> => MemoryExtensions.SequenceEqual(array, other);
 
-        public static bool IsCompletedSuccessfully(this Task task)
-        {
-#if NETSTANDARD2_0
-            return task.IsCompleted && !(task.IsCanceled || task.IsFaulted);
-#else
-            return task.IsCompletedSuccessfully;
-#endif
-        }
-
         // https://github.com/dotnet/runtime/blob/master/src/libraries/Common/src/System/Threading/Tasks/TaskTimeoutExtensions.cs
         public static Task WithCancellation(this Task task, CancellationToken cancellationToken)
         {

--- a/test/Knet.Kudu.Client.FunctionalTests/ClientStressTests.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/ClientStressTests.cs
@@ -268,16 +268,24 @@ namespace Knet.Kudu.Client.FunctionalTests
                 _cache = new ConcurrentDictionary<IPEndPoint, Task<KuduConnection>>();
             }
 
-            public Task<KuduConnection> ConnectAsync(ServerInfo serverInfo, CancellationToken cancellationToken = default)
+            public Task<KuduConnection> ConnectAsync(
+                ServerInfo serverInfo, CancellationToken cancellationToken = default)
             {
                 var connectionTask = _realConnectionFactory.ConnectAsync(serverInfo, cancellationToken);
                 _cache[serverInfo.Endpoint] = connectionTask;
                 return connectionTask;
             }
 
-            public Task<ServerInfo> GetServerInfoAsync(string uuid, string location, HostAndPort hostPort)
+            public Task<List<ServerInfo>> GetMasterServerInfoAsync(
+                HostAndPort hostPort, CancellationToken cancellationToken = default)
             {
-                return _realConnectionFactory.GetServerInfoAsync(uuid, location, hostPort);
+                return _realConnectionFactory.GetMasterServerInfoAsync(hostPort, cancellationToken);
+            }
+
+            public Task<ServerInfo> GetTabletServerInfoAsync(
+                HostAndPort hostPort, string uuid, string location, CancellationToken cancellationToken = default)
+            {
+                return _realConnectionFactory.GetTabletServerInfoAsync(hostPort, uuid, location, cancellationToken);
             }
 
             public async Task DisconnectRandomConnectionAsync()


### PR DESCRIPTION
Connect to every IP address per domain name. Allows changing kudu masters without restarting the client.

kudu.example.com
 - 127.0.0.1
 - 127.0.0.2
 - 127.0.0.3