### PR TITLE
Ty at different server on TABLET_NOT_RUNNING

### DIFF
--- a/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
+++ b/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
@@ -19,7 +19,10 @@ namespace Knet.Kudu.Client.Connection
         {
             _servers = servers;
             _leaderIndex = leaderIndex;
-            _randomIndex = _randomInt % servers.Count;
+
+            var numServers = servers.Count;
+            if (numServers > 0)
+                _randomIndex = _randomInt % numServers;
         }
 
         /// <summary>

--- a/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
+++ b/src/Knet.Kudu.Client/Connection/ServerInfoCache.cs
@@ -153,39 +153,27 @@ namespace Knet.Kudu.Client.Connection
         {
             var servers = _servers;
             var numServers = servers.Count;
-            var serverToRemove = -1;
+            var newServers = new List<ServerInfo>(numServers);
+            var leaderIndex = _leaderIndex;
 
             for (int i = 0; i < numServers; i++)
             {
                 var server = servers[i];
                 if (server.Uuid == uuid)
                 {
-                    serverToRemove = i;
-                    break;
-                }
-            }
+                    if (leaderIndex > i)
+                    {
+                        leaderIndex--;
+                    }
+                    else if (leaderIndex == i)
+                    {
+                        leaderIndex = -1;
+                    }
 
-            if (serverToRemove == -1)
-                return this;
-
-            var numNewServers = numServers - 1;
-            var newServers = new List<ServerInfo>(numNewServers);
-            for (int i = 0; i < numNewServers; i++)
-            {
-                if (i == serverToRemove)
                     continue;
+                }
 
-                newServers.Add(servers[i]);
-            }
-
-            var leaderIndex = _leaderIndex;
-            if (leaderIndex == serverToRemove)
-            {
-                leaderIndex = -1;
-            }
-            else if (leaderIndex > serverToRemove)
-            {
-                leaderIndex--;
+                newServers.Add(server);
             }
 
             return new ServerInfoCache(newServers, leaderIndex);

--- a/src/Knet.Kudu.Client/Internal/AvlTree.cs
+++ b/src/Knet.Kudu.Client/Internal/AvlTree.cs
@@ -29,7 +29,7 @@ using Knet.Kudu.Client.Util;
 
 namespace Knet.Kudu.Client.Internal
 {
-    public class AvlTree : IEnumerable<TableLocationEntry>
+    internal sealed class AvlTree : IEnumerable<TableLocationEntry>
     {
         private AvlNode _root;
 

--- a/src/Knet.Kudu.Client/Internal/AvlTreeExtensions.cs
+++ b/src/Knet.Kudu.Client/Internal/AvlTreeExtensions.cs
@@ -3,7 +3,7 @@ using Knet.Kudu.Client.Tablet;
 
 namespace Knet.Kudu.Client.Internal
 {
-    public static class AvlTreeExtensions
+    internal static class AvlTreeExtensions
     {
         public static TableLocationEntry FloorEntry(
             this AvlTree avlTree, ReadOnlySpan<byte> partitionKey)

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -762,6 +762,15 @@ namespace Knet.Kudu.Client
             cache.RemoveTablet(tablet.Partition.PartitionKeyStart);
         }
 
+        private void RemoveTabletServerFromCache<T>(KuduTabletRpc<T> rpc, ServerInfo serverInfo)
+        {
+            RemoteTablet tablet = rpc.Tablet.RemoveTabletServer(serverInfo.Uuid);
+            rpc.Tablet = tablet;
+
+            TableLocationsCache cache = GetTableLocationsCache(tablet.TableId);
+            cache.ReplaceTablet(tablet);
+        }
+
         private TableLocationsCache GetTableLocationsCache(string tableId)
         {
             return _tableLocations.GetOrAdd(
@@ -1360,7 +1369,7 @@ namespace Knet.Kudu.Client
                 {
                     // We're handling a tablet server that's telling us it doesn't
                     // have the tablet we're asking for.
-                    RemoveTabletFromCache(rpc);
+                    RemoveTabletServerFromCache(rpc, serverInfo);
                     throw new RecoverableException(status);
                 }
                 else if (errStatusCode == AppStatusPB.ErrorCode.ServiceUnavailable)

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -768,7 +768,7 @@ namespace Knet.Kudu.Client
             rpc.Tablet = tablet;
 
             TableLocationsCache cache = GetTableLocationsCache(tablet.TableId);
-            cache.ReplaceTablet(tablet);
+            cache.UpdateTablet(tablet);
         }
 
         private TableLocationsCache GetTableLocationsCache(string tableId)

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -1355,15 +1355,15 @@ namespace Knet.Kudu.Client
                 var errStatusCode = rpc.Error.Status.Code;
                 var status = KuduStatus.FromTabletServerErrorPB(rpc.Error);
 
-                if (errCode == TabletServerErrorPB.Code.TabletNotFound)
+                if (errCode == TabletServerErrorPB.Code.TabletNotFound ||
+                    errCode == TabletServerErrorPB.Code.TabletNotRunning)
                 {
                     // We're handling a tablet server that's telling us it doesn't
                     // have the tablet we're asking for.
                     RemoveTabletFromCache(rpc);
                     throw new RecoverableException(status);
                 }
-                else if (errCode == TabletServerErrorPB.Code.TabletNotRunning ||
-                    errStatusCode == AppStatusPB.ErrorCode.ServiceUnavailable)
+                else if (errStatusCode == AppStatusPB.ErrorCode.ServiceUnavailable)
                 {
                     throw new RecoverableException(status);
                 }

--- a/src/Knet.Kudu.Client/Tablet/RemoteTablet.cs
+++ b/src/Knet.Kudu.Client/Tablet/RemoteTablet.cs
@@ -58,6 +58,18 @@ namespace Knet.Kudu.Client.Tablet
         public ServerInfo GetLeaderServerInfo() =>
             _cache.GetLeaderServerInfo();
 
+        public RemoteTablet DemoteLeader(string uuid)
+        {
+            var cache = _cache.DemoteLeader(uuid);
+            return new RemoteTablet(TableId, TabletId, Partition, cache, Replicas);
+        }
+
+        public RemoteTablet RemoveTabletServer(string uuid)
+        {
+            var cache = _cache.RemoveTabletServer(uuid);
+            return new RemoteTablet(TableId, TabletId, Partition, cache, Replicas);
+        }
+
         public bool Equals(RemoteTablet other) =>
             TabletId == other.TabletId;
 

--- a/src/Knet.Kudu.Client/Tablet/TableLocationsCache.cs
+++ b/src/Knet.Kudu.Client/Tablet/TableLocationsCache.cs
@@ -88,9 +88,9 @@ namespace Knet.Kudu.Client.Tablet
                 // bound partition key on the request.
 
                 newEntries.Add(TableLocationEntry.NewNonCoveredRange(
-                    Array.Empty<byte>(),
-                    Array.Empty<byte>(),
-                    expiration));
+                            Array.Empty<byte>(),
+                            Array.Empty<byte>(),
+                            expiration));
             }
             else
             {
@@ -191,6 +191,26 @@ namespace Knet.Kudu.Client.Tablet
             }
         }
 
+        public void ReplaceTablet(RemoteTablet tablet)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+                if (_cache.Search(tablet.Partition.PartitionKeyStart, out var cacheEntry) &&
+                    cacheEntry.IsCoveredRange)
+                {
+                    var newEntry = TableLocationEntry.NewTablet(tablet, cacheEntry.Expiration);
+
+                    _cache.Delete(cacheEntry.LowerBoundPartitionKey);
+                    _cache.Insert(newEntry);
+                }
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
         public void ClearCache()
         {
             _lock.EnterWriteLock();
@@ -221,15 +241,14 @@ namespace Knet.Kudu.Client.Tablet
     public class TableLocationEntry
     {
         /// <summary>
-        /// The lower bound partition key, only set if this is a non-covered range.
+        /// The lower bound partition key.
         /// </summary>
-        private readonly byte[] _lowerBoundPartitionKey;
+        public byte[] LowerBoundPartitionKey { get; }
 
         /// <summary>
-        /// The upper bound partition key, only set if this is a non-covered range.
+        /// The upper bound partition key.
         /// </summary>
-        /// 
-        private readonly byte[] _upperBoundPartitionKey;
+        public byte[] UpperBoundPartitionKey { get; }
 
         /// <summary>
         /// The remote tablet, only set if this entry represents a tablet.
@@ -248,8 +267,8 @@ namespace Knet.Kudu.Client.Tablet
             long expiration)
         {
             Tablet = tablet;
-            _lowerBoundPartitionKey = lowerBoundPartitionKey;
-            _upperBoundPartitionKey = upperBoundPartitionKey;
+            LowerBoundPartitionKey = lowerBoundPartitionKey;
+            UpperBoundPartitionKey = upperBoundPartitionKey;
             Expiration = expiration;
         }
 
@@ -261,15 +280,7 @@ namespace Knet.Kudu.Client.Tablet
         /// <summary>
         /// If this entry is a covered range.
         /// </summary>
-        public bool IsCoveredRange => Tablet != null;
-
-        public byte[] LowerBoundPartitionKey => Tablet is null
-            ? _lowerBoundPartitionKey
-            : Tablet.Partition.PartitionKeyStart;
-
-        public byte[] UpperBoundPartitionKey => Tablet is null
-            ? _upperBoundPartitionKey
-            : Tablet.Partition.PartitionKeyEnd;
+        public bool IsCoveredRange => Tablet is not null;
 
         public static TableLocationEntry NewNonCoveredRange(
             byte[] lowerBoundPartitionKey,
@@ -283,10 +294,14 @@ namespace Knet.Kudu.Client.Tablet
                 expiration);
         }
 
-        public static TableLocationEntry NewTablet(
-            RemoteTablet tablet, long expiration)
+        public static TableLocationEntry NewTablet(RemoteTablet tablet, long expiration)
         {
-            return new TableLocationEntry(tablet, null, null, expiration);
+            var partition = tablet.Partition;
+            var lowerBoundPartitionKey = partition.PartitionKeyStart;
+            var upperBoundPartitionKey = partition.PartitionKeyEnd;
+
+            return new TableLocationEntry(
+                tablet, lowerBoundPartitionKey, upperBoundPartitionKey, expiration);
         }
     }
 }

--- a/src/Knet.Kudu.Client/Tablet/TableLocationsCache.cs
+++ b/src/Knet.Kudu.Client/Tablet/TableLocationsCache.cs
@@ -88,9 +88,9 @@ namespace Knet.Kudu.Client.Tablet
                 // bound partition key on the request.
 
                 newEntries.Add(TableLocationEntry.NewNonCoveredRange(
-                            Array.Empty<byte>(),
-                            Array.Empty<byte>(),
-                            expiration));
+                    Array.Empty<byte>(),
+                    Array.Empty<byte>(),
+                    expiration));
             }
             else
             {

--- a/src/Knet.Kudu.Client/Tablet/TableLocationsCache.cs
+++ b/src/Knet.Kudu.Client/Tablet/TableLocationsCache.cs
@@ -191,7 +191,7 @@ namespace Knet.Kudu.Client.Tablet
             }
         }
 
-        public void ReplaceTablet(RemoteTablet tablet)
+        public void UpdateTablet(RemoteTablet tablet)
         {
             _lock.EnterWriteLock();
             try
@@ -200,8 +200,6 @@ namespace Knet.Kudu.Client.Tablet
                     cacheEntry.IsCoveredRange)
                 {
                     var newEntry = TableLocationEntry.NewTablet(tablet, cacheEntry.Expiration);
-
-                    _cache.Delete(cacheEntry.LowerBoundPartitionKey);
                     _cache.Insert(newEntry);
                 }
             }

--- a/test/Knet.Kudu.Client.FunctionalTests/MiniCluster/KuduTestHarness.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/MiniCluster/KuduTestHarness.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Knet.Kudu.Client.Connection;
 using Knet.Kudu.Client.Tablet;
@@ -32,6 +33,16 @@ namespace Knet.Kudu.Client.FunctionalTests.MiniCluster
         public KuduClient CreateClient() => _miniCluster.CreateClient();
 
         public KuduClientBuilder CreateClientBuilder() => _miniCluster.CreateClientBuilder();
+
+        public List<HostAndPort> GetMasterServers()
+        {
+            return _miniCluster.GetMasterServers();
+        }
+
+        public List<HostAndPort> GetTabletServers()
+        {
+            return _miniCluster.GetTabletServers();
+        }
 
         /// <summary>
         /// Helper method to easily kill the leader master.

--- a/test/Knet.Kudu.Client.FunctionalTests/MiniCluster/MiniKuduCluster.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/MiniCluster/MiniKuduCluster.cs
@@ -147,6 +147,16 @@ namespace Knet.Kudu.Client.FunctionalTests.MiniCluster
             return KuduClient.NewBuilder(_masterServers.Keys.ToList());
         }
 
+        public List<HostAndPort> GetMasterServers()
+        {
+            return _masterServers.Keys.ToList();
+        }
+
+        public List<HostAndPort> GetTabletServers()
+        {
+            return _tabletServers.Keys.ToList();
+        }
+
         /// <summary>
         /// Starts a master server identified by a host and port.
         /// Does nothing if the server was already running.


### PR DESCRIPTION
If a tablet server is quiescing, blacklist that server and try the scan
on a different server.

Prior to this change, the scan would be continually retried on the
same server, leading to a timeout.