### PR TITLE
Fix negotiation over TLSv1.3

### DIFF
--- a/src/Knet.Kudu.Client/Negotiate/KuduTlsAuthenticationStream.cs
+++ b/src/Knet.Kudu.Client/Negotiate/KuduTlsAuthenticationStream.cs
@@ -78,16 +78,12 @@ namespace Knet.Kudu.Client.Negotiate
             throw new NotImplementedException();
         }
 
-        private Task SendHandshakeAsync(
-            ReadOnlyMemory<byte> buffer,
-            CancellationToken cancellationToken = default)
+        private Task SendHandshakeAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             return _negotiator.SendTlsHandshakeAsync(buffer, cancellationToken);
         }
 
-        private async Task<int> ReceiveHandshakeAsync(
-            Memory<byte> buffer,
-            CancellationToken cancellationToken = default)
+        private async Task<int> ReceiveHandshakeAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (buffer.Length == 0)
             {

--- a/src/Knet.Kudu.Client/Negotiate/Negotiator.cs
+++ b/src/Knet.Kudu.Client/Negotiate/Negotiator.cs
@@ -385,8 +385,7 @@ namespace Knet.Kudu.Client.Negotiate
             return SendAsync(header, context, cancellationToken);
         }
 
-        internal Task SendTlsHandshakeAsync(
-            ReadOnlyMemory<byte> tlsHandshake, CancellationToken cancellationToken)
+        internal Task SendTlsHandshakeAsync(ReadOnlyMemory<byte> tlsHandshake, CancellationToken cancellationToken)
         {
             var request = new NegotiatePB
             {

--- a/src/Knet.Kudu.Client/Negotiate/Negotiator.cs
+++ b/src/Knet.Kudu.Client/Negotiate/Negotiator.cs
@@ -385,7 +385,8 @@ namespace Knet.Kudu.Client.Negotiate
             return SendAsync(header, context, cancellationToken);
         }
 
-        internal Task<NegotiatePB> SendTlsHandshakeAsync(byte[] tlsHandshake, CancellationToken cancellationToken)
+        internal Task SendTlsHandshakeAsync(
+            ReadOnlyMemory<byte> tlsHandshake, CancellationToken cancellationToken)
         {
             var request = new NegotiatePB
             {
@@ -393,7 +394,12 @@ namespace Knet.Kudu.Client.Negotiate
                 TlsHandshake = UnsafeByteOperations.UnsafeWrap(tlsHandshake)
             };
 
-            return SendReceiveAsync(request, cancellationToken);
+            return SendAsync(request, cancellationToken);
+        }
+
+        internal Task<NegotiatePB> ReceiveTlsHandshakeAsync(CancellationToken cancellationToken)
+        {
+            return ReceiveAsync(cancellationToken);
         }
 
         internal Task<NegotiatePB> SendGssApiTokenAsync(
@@ -413,10 +419,15 @@ namespace Knet.Kudu.Client.Negotiate
             return SendReceiveAsync(request, cancellationToken);
         }
 
-        private async Task<NegotiatePB> SendReceiveAsync(NegotiatePB request, CancellationToken cancellationToken)
+        private Task SendAsync(NegotiatePB request, CancellationToken cancellationToken)
         {
             var header = new RequestHeader { CallId = SaslNegotiationCallId };
-            await SendAsync(header, request, cancellationToken).ConfigureAwait(false);
+            return SendAsync(header, request, cancellationToken);
+        }
+
+        private async Task<NegotiatePB> SendReceiveAsync(NegotiatePB request, CancellationToken cancellationToken)
+        {
+            await SendAsync(request, cancellationToken).ConfigureAwait(false);
             var response = await ReceiveAsync(cancellationToken).ConfigureAwait(false);
             return response;
         }

--- a/test/Knet.Kudu.Client.FunctionalTests/Knet.Kudu.Client.FunctionalTests.csproj
+++ b/test/Knet.Kudu.Client.FunctionalTests/Knet.Kudu.Client.FunctionalTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Knet.Kudu.Binary" Version="1.14.0" />
+    <PackageReference Include="Knet.Kudu.Binary" Version="1.15.0" />
     <PackageReference Include="McMaster.Extensions.Xunit" Version="0.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
The TLS negotiation in KRPC protocol assumes a whole number of round trips between client and server. For TLS 1.3, the exchange has 1.5 round trips (the client is the last sender rather than the server) which breaks negotiation.

Don't wait for the server to respond after sending the final piece of data.

Also upgrade functional tests to use Kudu 1.15.