### PR TITLE
Only allow a single concurrent ConnectToMaster RPC

### DIFF
--- a/src/Knet.Kudu.Client/Assembly.cs
+++ b/src/Knet.Kudu.Client/Assembly.cs
@@ -1,0 +1,11 @@
+#if !NET5_0_OR_GREATER
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit { }
+}
+
+#endif

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -1498,25 +1498,8 @@ namespace Knet.Kudu.Client
         internal async ValueTask<HostAndPort> FindLeaderMasterServerAsync(
             CancellationToken cancellationToken = default)
         {
-            // Consult the cache to determine the current leader master.
-            //
-            // If one isn't found, issue an RPC that retries until the leader master
-            // is discovered. We don't need the RPC's results; it's just a simple way to
-            // wait until a leader master is elected.
-
-            var masterLeaderInfo = _masterLeaderInfo;
-            if (masterLeaderInfo is null)
-            {
-                // If there's no leader master, this will time out and throw an exception.
-                await GetTabletServersAsync(cancellationToken).ConfigureAwait(false);
-
-                masterLeaderInfo = _masterLeaderInfo;
-                if (masterLeaderInfo is null)
-                {
-                    throw new NonRecoverableException(KuduStatus.IllegalState(
-                        "Master leader could not be found"));
-                }
-            }
+            var masterLeaderInfo = await GetMasterLeaderInfoAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             return masterLeaderInfo.ServerInfo.HostPort;
         }

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -1487,7 +1487,7 @@ namespace Knet.Kudu.Client
         private ServerInfo GetServerInfo(RemoteTablet tablet, ReplicaSelection replicaSelection)
         {
             var masterLeaderInfo = _masterLeaderInfo;
-            return tablet.GetServerInfo(replicaSelection, masterLeaderInfo.Location);
+            return tablet.GetServerInfo(replicaSelection, masterLeaderInfo?.Location);
         }
 
         internal SignedTokenPB GetAuthzToken(string tableId)

--- a/src/Knet.Kudu.Client/Util/ProtobufHelper.cs
+++ b/src/Knet.Kudu.Client/Util/ProtobufHelper.cs
@@ -159,6 +159,18 @@ namespace Knet.Kudu.Client.Util
             return partitionPb;
         }
 
+        public static HiveMetastoreConfig ToHiveMetastoreConfig(
+            this Protobuf.Master.HiveMetastoreConfig hmsConfig)
+        {
+            if (hmsConfig is null)
+                return null;
+
+            return new HiveMetastoreConfig(
+                hmsConfig.HmsUris,
+                hmsConfig.HmsSaslEnabled,
+                hmsConfig.HmsUuid);
+        }
+
         public static HostPortPB ToHostPortPb(HostAndPort hostAndPort)
         {
             return new HostPortPB


### PR DESCRIPTION
Previously there was no locking around ConnectToClusterAsync(). If a
new client was issued many concurrent requests, each request would
attempt to connect to the cluster, until there was a successful cached
response.

While the connection caching limits a single connection per IP address,
after establishing a connection, each parent request would still issue
a ConnectToMaster RPC.

This PR adds locking so that only a single concurrent cluster connect
can happen at a time.