### PR TITLE
Fix some flaky tests

### DIFF
--- a/test/Knet.Kudu.Client.FunctionalTests/Knet.Kudu.Client.FunctionalTests.csproj
+++ b/test/Knet.Kudu.Client.FunctionalTests/Knet.Kudu.Client.FunctionalTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Knet.Kudu.Binary" Version="1.15.0" />
     <PackageReference Include="McMaster.Extensions.Xunit" Version="0.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Knet.Kudu.Client.FunctionalTests/MultipleLeaderFailoverTests.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/MultipleLeaderFailoverTests.cs
@@ -45,9 +45,7 @@ namespace Knet.Kudu.Client.FunctionalTests
             }
 
             await session.FlushAsync();
-
-            var rowCount = await ClientTestUtil.CountRowsAsync(client, table);
-            Assert.Equal(rowsPerIteration, rowCount);
+            await ClientTestUtil.WaitUntilRowCountAsync(client, table, rowsPerIteration);
 
             int currentRows = rowsPerIteration;
             for (int i = 0; i < numIterations; i++)
@@ -73,12 +71,10 @@ namespace Knet.Kudu.Client.FunctionalTests
                 if (!restart)
                     await harness.StartAllTabletServersAsync();
 
-                rowCount = await ClientTestUtil.CountRowsAsync(client, table);
-                Assert.Equal(currentRows, rowCount);
+                await ClientTestUtil.WaitUntilRowCountAsync(client, table, currentRows);
             }
 
-            rowCount = await ClientTestUtil.CountRowsAsync(client, table);
-            Assert.Equal(totalRowsToInsert, rowCount);
+            await ClientTestUtil.WaitUntilRowCountAsync(client, table, totalRowsToInsert);
         }
     }
 }

--- a/test/Knet.Kudu.Client.FunctionalTests/Util/ClientTestUtil.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/Util/ClientTestUtil.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace Knet.Kudu.Client.FunctionalTests.Util
 {
@@ -238,6 +239,25 @@ namespace Knet.Kudu.Client.FunctionalTests.Util
             rowStrings.Sort();
 
             return rowStrings;
+        }
+
+        public static async Task WaitUntilRowCountAsync(
+            KuduClient client, KuduTable table, int rowCount)
+        {
+            long readCount = 0;
+
+            for (int i = 0; i < 20; i++)
+            {
+                var scanner = client.NewScanBuilder(table).Build();
+                readCount = await CountRowsInScanAsync(scanner);
+
+                if (readCount == rowCount)
+                    return;
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.Equal(rowCount, readCount);
         }
     }
 }

--- a/test/Knet.Kudu.Client.FunctionalTests/Util/ClientTestUtil.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/Util/ClientTestUtil.cs
@@ -246,7 +246,7 @@ namespace Knet.Kudu.Client.FunctionalTests.Util
         {
             long readCount = 0;
 
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < 10; i++)
             {
                 var scanner = client.NewScanBuilder(table).Build();
                 readCount = await CountRowsInScanAsync(scanner);

--- a/test/Knet.Kudu.Client.Tests/Knet.Kudu.Client.Tests.csproj
+++ b/test/Knet.Kudu.Client.Tests/Knet.Kudu.Client.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Kudu is eventually consistent and these tests weren't using any of Kudu's mechanisms for read-your-own-writes. Introduce a helper method to wait until the expected number of rows have been written.