### PR TITLE
Optimize ResultSet with unsafe code

### DIFF
--- a/src/Knet.Kudu.Client/Protocol/SidecarOffset.cs
+++ b/src/Knet.Kudu.Client/Protocol/SidecarOffset.cs
@@ -1,0 +1,18 @@
+namespace Knet.Kudu.Client.Protocol
+{
+    public readonly struct SidecarOffset
+    {
+        public readonly int Start;
+
+        public readonly int Length;
+
+        public SidecarOffset(int start, int length)
+        {
+            Start = start;
+            Length = length;
+        }
+
+        public override string ToString() =>
+            $"Start: {Start}, Length: {Length}";
+    }
+}

--- a/src/Knet.Kudu.Client/Requests/ScanRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/ScanRequest.cs
@@ -169,7 +169,7 @@ namespace Knet.Kudu.Client.Requests
             var output = Output;
             if (output is not null)
             {
-                output = null;
+                Output = null;
                 output.ResultSet.Dispose();
             }
         }

--- a/src/Knet.Kudu.Client/ResultSet.cs
+++ b/src/Knet.Kudu.Client/ResultSet.cs
@@ -35,9 +35,6 @@ namespace Knet.Kudu.Client
             _nonNullBitmapSidecarOffsets = nonNullBitmapSidecarOffsets;
             _schema = schema;
             Count = count;
-
-            // TODO: Validation, so we can safely use these unsafe methods
-            // TODO: Better dispose behavior
         }
 
         public KuduSchema Schema

--- a/src/Knet.Kudu.Client/Scanner/ResultSetFactory.cs
+++ b/src/Knet.Kudu.Client/Scanner/ResultSetFactory.cs
@@ -28,7 +28,7 @@ namespace Knet.Kudu.Client.Scanner
             if (data.Columns.Count == 0)
             {
                 // Empty projection, usually used for quick row counting.
-                return new ResultSet(null, schema, data.NumRows, null, null, null);
+                return CreateEmptyResultSet(schema, data.NumRows);
             }
 
             var columns = data.Columns;
@@ -83,10 +83,21 @@ namespace Knet.Kudu.Client.Scanner
             if (data is null || data.NumRows == 0)
             {
                 // Empty projection, usually used for quick row counting.
-                return new ResultSet(null, schema, data.NumRows, null, null, null);
+                return CreateEmptyResultSet(schema, data.NumRows);
             }
 
             throw new NotImplementedException("Support for row data will be implemented in a future PR");
+        }
+
+        private static ResultSet CreateEmptyResultSet(KuduSchema schema, long numRows)
+        {
+            return new ResultSet(
+                null,
+                schema,
+                numRows,
+                Array.Empty<SidecarOffset>(),
+                Array.Empty<SidecarOffset>(),
+                Array.Empty<SidecarOffset>());
         }
     }
 }

--- a/src/Knet.Kudu.Client/Scanner/ResultSetFactory.cs
+++ b/src/Knet.Kudu.Client/Scanner/ResultSetFactory.cs
@@ -34,9 +34,9 @@ namespace Knet.Kudu.Client.Scanner
             var columns = data.Columns;
             var numColumns = columns.Count;
 
-            var dataSidecarOffsets = new int[numColumns];
-            var varlenDataSidecarOffsets = new int[numColumns];
-            var nonNullBitmapSidecarOffsets = new int[numColumns];
+            var dataSidecarOffsets = new SidecarOffset[numColumns];
+            var varlenDataSidecarOffsets = new SidecarOffset[numColumns];
+            var nonNullBitmapSidecarOffsets = new SidecarOffset[numColumns];
 
             for (int i = 0; i < numColumns; i++)
             {
@@ -61,7 +61,7 @@ namespace Knet.Kudu.Client.Scanner
                 }
                 else
                 {
-                    nonNullBitmapSidecarOffsets[i] = -1;
+                    nonNullBitmapSidecarOffsets[i] = new SidecarOffset(-1, 0);
                 }
             }
 


### PR DESCRIPTION
By performing some bounds checks on ResultSet ahead of time, we can avoid unnecessary bounds checks on each read method on RowResult.