### PR TITLE
Misc KuduRpc Cleanup

### DIFF
--- a/src/Knet.Kudu.Client/Connection/KuduConnection.cs
+++ b/src/Knet.Kudu.Client/Connection/KuduConnection.cs
@@ -64,7 +64,7 @@ namespace Knet.Kudu.Client.Connection
                 {
                     // Guarantee the disconnected callback is invoked if
                     // the connection is already closed.
-                    InvokeDisconnectedCallback();
+                    InvokeDisconnectedCallback(_closedException);
                 }
             }
         }
@@ -331,8 +331,7 @@ namespace Knet.Kudu.Client.Connection
             lock (_inflightRpcs)
             {
                 _closedException = closedException;
-
-                InvokeDisconnectedCallback();
+                InvokeDisconnectedCallback(closedException);
 
                 foreach (var inflightMessage in _inflightRpcs.Values)
                     inflightMessage.TrySetException(closedException);
@@ -349,11 +348,11 @@ namespace Knet.Kudu.Client.Connection
         /// <summary>
         /// The caller must hold the _inflightMessages lock.
         /// </summary>
-        private void InvokeDisconnectedCallback()
+        private void InvokeDisconnectedCallback(RecoverableException exception)
         {
             try
             {
-                _disconnectedCallback.Invoke(_closedException.InnerException);
+                _disconnectedCallback.Invoke(exception.InnerException);
             }
             catch { }
         }

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -255,7 +255,8 @@ namespace Knet.Kudu.Client
         private async Task<IsCreateTableDoneResponsePB> WaitForCreateTableDoneAsync(
             TableIdentifierPB tableId, CancellationToken cancellationToken)
         {
-            var rpc = new IsCreateTableDoneRequest(tableId);
+            var request = new IsCreateTableDoneRequestPB { Table = tableId };
+            var rpc = new IsCreateTableDoneRequest(request);
 
             while (true)
             {
@@ -273,7 +274,8 @@ namespace Knet.Kudu.Client
         private async Task<IsAlterTableDoneResponsePB> WaitForAlterTableDoneAsync(
             TableIdentifierPB tableId, CancellationToken cancellationToken)
         {
-            var rpc = new IsAlterTableDoneRequest(tableId);
+            var request = new IsAlterTableDoneRequestPB { Table = tableId };
+            var rpc = new IsAlterTableDoneRequest(request);
 
             while (true)
             {
@@ -370,7 +372,8 @@ namespace Knet.Kudu.Client
             string tableName, CancellationToken cancellationToken = default)
         {
             var table = new TableIdentifierPB { TableName = tableName };
-            var rpc = new GetTableStatisticsRequest(table);
+            var request = new GetTableStatisticsRequestPB { Table = table };
+            var rpc = new GetTableStatisticsRequest(request);
             var response = await SendRpcAsync(rpc, cancellationToken)
                 .ConfigureAwait(false);
 

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -1515,11 +1515,12 @@ namespace Knet.Kudu.Client
         {
             // Set the propagated timestamp so that the next time we send a message to
             // the server the message includes the last propagated timestamp.
-            long lastPropagatedTimestamp = LastPropagatedTimestamp;
-            if (rpc.ExternalConsistencyMode == ExternalConsistencyMode.ClientPropagated &&
-                lastPropagatedTimestamp != NoTimestamp)
+            if (rpc.ExternalConsistencyMode == ExternalConsistencyMode.ClientPropagated)
             {
-                rpc.PropagatedTimestamp = lastPropagatedTimestamp;
+                long lastPropagatedTimestamp = LastPropagatedTimestamp;
+
+                if (lastPropagatedTimestamp != NoTimestamp)
+                    rpc.PropagatedTimestamp = lastPropagatedTimestamp;
             }
 
             string tableId = rpc.TableId;

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -569,7 +569,8 @@ namespace Knet.Kudu.Client
             var rpc = new WriteRequest(
                 request,
                 table.TableId,
-                tablet.Partition.PartitionKeyStart);
+                tablet.Partition.PartitionKeyStart,
+                externalConsistencyMode);
 
             var response = await SendRpcAsync(rpc, cancellationToken)
                 .ConfigureAwait(false);

--- a/src/Knet.Kudu.Client/Requests/AbortTransactionRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/AbortTransactionRequest.cs
@@ -5,16 +5,15 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class AbortTransactionRequest : KuduTxnRpc<AbortTransactionResponsePB>
+    internal sealed class AbortTransactionRequest : KuduTxnRpc<AbortTransactionResponsePB>
     {
         private readonly AbortTransactionRequestPB _request;
 
         public AbortTransactionRequest(AbortTransactionRequestPB request)
         {
+            MethodName = "AbortTransaction";
             _request = request;
         }
-
-        public override string MethodName => "AbortTransaction";
 
         public override int CalculateSize() => _request.CalculateSize();
 

--- a/src/Knet.Kudu.Client/Requests/AlterTableRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/AlterTableRequest.cs
@@ -5,14 +5,13 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class AlterTableRequest : KuduMasterRpc<AlterTableResponse>
+    internal sealed class AlterTableRequest : KuduMasterRpc<AlterTableResponse>
     {
         private readonly AlterTableRequestPB _request;
 
-        public override string MethodName => "AlterTable";
-
         public AlterTableRequest(AlterTableRequestPB request)
         {
+            MethodName = "AlterTable";
             _request = request;
 
             // We don't need to set required feature ADD_DROP_RANGE_PARTITIONS here,

--- a/src/Knet.Kudu.Client/Requests/BeginTransactionRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/BeginTransactionRequest.cs
@@ -1,15 +1,19 @@
 using System.Buffers;
-using Google.Protobuf;
 using Knet.Kudu.Client.Protobuf.Transactions;
 using Knet.Kudu.Client.Protocol;
+using Knet.Kudu.Client.Util;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class BeginTransactionRequest : KuduTxnRpc<BeginTransactionResponsePB>
+    internal sealed class BeginTransactionRequest : KuduTxnRpc<BeginTransactionResponsePB>
     {
-        private static readonly byte[] _requestBytes = new BeginTransactionRequestPB().ToByteArray();
+        private static readonly byte[] _requestBytes = ProtobufHelper.ToByteArray(
+            new BeginTransactionRequestPB());
 
-        public override string MethodName => "BeginTransaction";
+        public BeginTransactionRequest()
+        {
+            MethodName = "BeginTransaction";
+        }
 
         public override int CalculateSize() => _requestBytes.Length;
 

--- a/src/Knet.Kudu.Client/Requests/CommitTransactionRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/CommitTransactionRequest.cs
@@ -5,16 +5,15 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class CommitTransactionRequest : KuduTxnRpc<CommitTransactionResponsePB>
+    internal sealed class CommitTransactionRequest : KuduTxnRpc<CommitTransactionResponsePB>
     {
         private readonly CommitTransactionRequestPB _request;
 
         public CommitTransactionRequest(CommitTransactionRequestPB request)
         {
+            MethodName = "CommitTransaction";
             _request = request;
         }
-
-        public override string MethodName => "CommitTransaction";
 
         public override int CalculateSize() => _request.CalculateSize();
 

--- a/src/Knet.Kudu.Client/Requests/ConnectToMasterRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/ConnectToMasterRequest.cs
@@ -1,26 +1,26 @@
 using System.Buffers;
-using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Knet.Kudu.Client.Protobuf.Master;
 using Knet.Kudu.Client.Protocol;
+using Knet.Kudu.Client.Util;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class ConnectToMasterRequest : KuduMasterRpc<ConnectToMasterResponsePB>
+    internal sealed class ConnectToMasterRequest : KuduMasterRpc<ConnectToMasterResponsePB>
     {
         private static readonly RepeatedField<uint> _requiredFeatures = new()
         {
             (uint)MasterFeatures.ConnectToMaster
         };
 
-        private static readonly byte[] _requestBytes = new ConnectToMasterRequestPB().ToByteArray();
+        private static readonly byte[] _requestBytes = ProtobufHelper.ToByteArray(
+            new ConnectToMasterRequestPB());
 
         public ConnectToMasterRequest()
         {
+            MethodName = "ConnectToMaster";
             RequiredFeatures = _requiredFeatures;
         }
-
-        public override string MethodName => "ConnectToMaster";
 
         public override int CalculateSize() => _requestBytes.Length;
 

--- a/src/Knet.Kudu.Client/Requests/CreateTableRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/CreateTableRequest.cs
@@ -5,14 +5,13 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class CreateTableRequest : KuduMasterRpc<CreateTableResponsePB>
+    internal sealed class CreateTableRequest : KuduMasterRpc<CreateTableResponsePB>
     {
         private readonly CreateTableRequestPB _request;
 
-        public override string MethodName => "CreateTable";
-
         public CreateTableRequest(CreateTableRequestPB request)
         {
+            MethodName = "CreateTable";
             _request = request;
 
             // We don't need to set required feature ADD_DROP_RANGE_PARTITIONS here,

--- a/src/Knet.Kudu.Client/Requests/DeleteTableRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/DeleteTableRequest.cs
@@ -5,14 +5,13 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class DeleteTableRequest : KuduMasterRpc<DeleteTableResponsePB>
+    internal sealed class DeleteTableRequest : KuduMasterRpc<DeleteTableResponsePB>
     {
         private readonly DeleteTableRequestPB _request;
 
-        public override string MethodName => "DeleteTable";
-
         public DeleteTableRequest(DeleteTableRequestPB request)
         {
+            MethodName = "DeleteTable";
             _request = request;
         }
 

--- a/src/Knet.Kudu.Client/Requests/GetTableLocationsRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/GetTableLocationsRequest.cs
@@ -5,14 +5,13 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class GetTableLocationsRequest : KuduMasterRpc<GetTableLocationsResponsePB>
+    internal sealed class GetTableLocationsRequest : KuduMasterRpc<GetTableLocationsResponsePB>
     {
         private readonly GetTableLocationsRequestPB _request;
 
-        public override string MethodName => "GetTableLocations";
-
         public GetTableLocationsRequest(GetTableLocationsRequestPB request)
         {
+            MethodName = "GetTableLocations";
             _request = request;
         }
 

--- a/src/Knet.Kudu.Client/Requests/GetTableSchemaRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/GetTableSchemaRequest.cs
@@ -6,7 +6,7 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class GetTableSchemaRequest : KuduMasterRpc<GetTableSchemaResponsePB>
+    internal sealed class GetTableSchemaRequest : KuduMasterRpc<GetTableSchemaResponsePB>
     {
         private static readonly RepeatedField<uint> _requiredFeatures = new()
         {
@@ -15,12 +15,11 @@ namespace Knet.Kudu.Client.Requests
 
         private readonly GetTableSchemaRequestPB _request;
 
-        public override string MethodName => "GetTableSchema";
-
         public GetTableSchemaRequest(
             GetTableSchemaRequestPB request,
             bool requiresAuthzTokenSupport)
         {
+            MethodName = "GetTableSchema";
             _request = request;
 
             if (requiresAuthzTokenSupport)

--- a/src/Knet.Kudu.Client/Requests/GetTableStatisticsRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/GetTableStatisticsRequest.cs
@@ -5,15 +5,14 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class GetTableStatisticsRequest : KuduMasterRpc<GetTableStatisticsResponsePB>
+    internal sealed class GetTableStatisticsRequest : KuduMasterRpc<GetTableStatisticsResponsePB>
     {
         private readonly GetTableStatisticsRequestPB _request;
 
-        public override string MethodName => "GetTableStatistics";
-
-        public GetTableStatisticsRequest(TableIdentifierPB table)
+        public GetTableStatisticsRequest(GetTableStatisticsRequestPB request)
         {
-            _request = new GetTableStatisticsRequestPB { Table = table };
+            MethodName = "GetTableStatistics";
+            _request = request;
         }
 
         public override int CalculateSize() => _request.CalculateSize();

--- a/src/Knet.Kudu.Client/Requests/GetTransactionStateRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/GetTransactionStateRequest.cs
@@ -5,16 +5,15 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class GetTransactionStateRequest : KuduTxnRpc<GetTransactionStateResponsePB>
+    internal sealed class GetTransactionStateRequest : KuduTxnRpc<GetTransactionStateResponsePB>
     {
         private readonly GetTransactionStateRequestPB _request;
 
         public GetTransactionStateRequest(GetTransactionStateRequestPB request)
         {
+            MethodName = "GetTransactionState";
             _request = request;
         }
-
-        public override string MethodName => "GetTransactionState";
 
         public override int CalculateSize() => _request.CalculateSize();
 

--- a/src/Knet.Kudu.Client/Requests/IsAlterTableDoneRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/IsAlterTableDoneRequest.cs
@@ -5,15 +5,14 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class IsAlterTableDoneRequest : KuduMasterRpc<IsAlterTableDoneResponsePB>
+    internal sealed class IsAlterTableDoneRequest : KuduMasterRpc<IsAlterTableDoneResponsePB>
     {
         private readonly IsAlterTableDoneRequestPB _request;
 
-        public override string MethodName => "IsAlterTableDone";
-
-        public IsAlterTableDoneRequest(TableIdentifierPB tableId)
+        public IsAlterTableDoneRequest(IsAlterTableDoneRequestPB request)
         {
-            _request = new IsAlterTableDoneRequestPB { Table = tableId };
+            MethodName = "IsAlterTableDone";
+            _request = request;
         }
 
         public override int CalculateSize() => _request.CalculateSize();

--- a/src/Knet.Kudu.Client/Requests/IsCreateTableDoneRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/IsCreateTableDoneRequest.cs
@@ -5,15 +5,14 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class IsCreateTableDoneRequest : KuduMasterRpc<IsCreateTableDoneResponsePB>
+    internal sealed class IsCreateTableDoneRequest : KuduMasterRpc<IsCreateTableDoneResponsePB>
     {
         private readonly IsCreateTableDoneRequestPB _request;
 
-        public override string MethodName => "IsCreateTableDone";
-
-        public IsCreateTableDoneRequest(TableIdentifierPB tableId)
+        public IsCreateTableDoneRequest(IsCreateTableDoneRequestPB request)
         {
-            _request = new IsCreateTableDoneRequestPB { Table = tableId };
+            MethodName = "IsCreateTableDone";
+            _request = request;
         }
 
         public override int CalculateSize() => _request.CalculateSize();

--- a/src/Knet.Kudu.Client/Requests/KeepAliveRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/KeepAliveRequest.cs
@@ -6,7 +6,7 @@ using Knet.Kudu.Client.Tablet;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class KeepAliveRequest : KuduTabletRpc<ScannerKeepAliveResponsePB>
+    internal sealed class KeepAliveRequest : KuduTabletRpc<ScannerKeepAliveResponsePB>
     {
         private readonly ScannerKeepAliveRequestPB _request;
 
@@ -22,15 +22,12 @@ namespace Knet.Kudu.Client.Requests
                 ScannerId = UnsafeByteOperations.UnsafeWrap(scannerId),
             };
 
+            MethodName = "ScannerKeepAlive";
             ReplicaSelection = replicaSelection;
             TableId = tableId;
             Tablet = tablet;
             PartitionKey = partitionKey;
         }
-
-        public override string MethodName => "ScannerKeepAlive";
-
-        public override ReplicaSelection ReplicaSelection { get; }
 
         public override int CalculateSize() => _request.CalculateSize();
 

--- a/src/Knet.Kudu.Client/Requests/KeepTransactionAliveRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/KeepTransactionAliveRequest.cs
@@ -5,16 +5,15 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class KeepTransactionAliveRequest : KuduTxnRpc<KeepTransactionAliveResponsePB>
+    internal sealed class KeepTransactionAliveRequest : KuduTxnRpc<KeepTransactionAliveResponsePB>
     {
         private readonly KeepTransactionAliveRequestPB _request;
 
         public KeepTransactionAliveRequest(KeepTransactionAliveRequestPB request)
         {
+            MethodName = "KeepTransactionAlive";
             _request = request;
         }
-
-        public override string MethodName => "KeepTransactionAlive";
 
         public override int CalculateSize() => _request.CalculateSize();
 

--- a/src/Knet.Kudu.Client/Requests/KuduMasterRpc.cs
+++ b/src/Knet.Kudu.Client/Requests/KuduMasterRpc.cs
@@ -1,0 +1,14 @@
+using Knet.Kudu.Client.Protobuf.Master;
+
+namespace Knet.Kudu.Client.Requests
+{
+    internal abstract class KuduMasterRpc<T> : KuduRpc<T>
+    {
+        public MasterErrorPB Error { get; protected set; }
+
+        public KuduMasterRpc()
+        {
+            ServiceName = MasterServiceName;
+        }
+    }
+}

--- a/src/Knet.Kudu.Client/Requests/KuduRpc.cs
+++ b/src/Knet.Kudu.Client/Requests/KuduRpc.cs
@@ -19,20 +19,19 @@ namespace Knet.Kudu.Client.Requests
         protected const string TabletServerServiceName = "kudu.tserver.TabletServerService";
         protected const string TxnManagerServiceName = "kudu.transactions.TxnManagerService";
 
-        public abstract string ServiceName { get; }
+        public string ServiceName { get; init; }
 
-        public abstract string MethodName { get; }
+        public string MethodName { get; init; }
 
         /// <summary>
         /// Returns the set of application-specific feature flags required to service the RPC.
         /// </summary>
-        public RepeatedField<uint> RequiredFeatures { get; protected set; }
+        public RepeatedField<uint> RequiredFeatures { get; init; }
 
         /// <summary>
         /// The external consistency mode for this RPC.
-        /// TODO make this cover most if not all RPCs (right now only scans and writes use this).
         /// </summary>
-        public ExternalConsistencyMode ExternalConsistencyMode { get; set; } =
+        public ExternalConsistencyMode ExternalConsistencyMode { get; init; } =
             ExternalConsistencyMode.ClientPropagated;
 
         /// <summary>
@@ -49,7 +48,7 @@ namespace Knet.Kudu.Client.Requests
         /// If this RPC needs to be tracked on the client and server-side.
         /// Some RPCs require exactly-once semantics which is enabled by tracking them.
         /// </summary>
-        public bool IsRequestTracked { get; protected set; }
+        public bool IsRequestTracked { get; init; }
 
         internal long SequenceId { get; set; } = RequestTracker.NoSeqNo;
 
@@ -67,42 +66,51 @@ namespace Knet.Kudu.Client.Requests
 
     internal abstract class KuduMasterRpc<T> : KuduRpc<T>
     {
-        public override string ServiceName => MasterServiceName;
-
         public MasterErrorPB Error { get; protected set; }
+
+        public KuduMasterRpc()
+        {
+            ServiceName = MasterServiceName;
+        }
     }
 
     internal abstract class KuduTxnRpc<T> : KuduRpc<T>
     {
-        public override string ServiceName => TxnManagerServiceName;
-
         public TxnManagerErrorPB Error { get; protected set; }
+
+        public KuduTxnRpc()
+        {
+            ServiceName = TxnManagerServiceName;
+        }
     }
 
     internal abstract class KuduTabletRpc<T> : KuduRpc<T>
     {
-        public override string ServiceName => TabletServerServiceName;
-
         public long PropagatedTimestamp { get; set; } = KuduClient.NoTimestamp;
 
         /// <summary>
         /// Returns the partition key this RPC is for.
         /// </summary>
-        public byte[] PartitionKey { get; protected set; }
+        public byte[] PartitionKey { get; init; }
 
         public RemoteTablet Tablet { get; internal set; }
 
-        public virtual ReplicaSelection ReplicaSelection => ReplicaSelection.LeaderOnly;
+        public ReplicaSelection ReplicaSelection { get; init; } = ReplicaSelection.LeaderOnly;
 
-        public bool NeedsAuthzToken { get; protected set; }
+        public bool NeedsAuthzToken { get; init; }
 
         internal SignedTokenPB AuthzToken { get; set; }
 
         /// <summary>
         /// The table this RPC is for.
         /// </summary>
-        public string TableId { get; protected set; }
+        public string TableId { get; init; }
 
         public TabletServerErrorPB Error { get; protected set; }
+
+        public KuduTabletRpc()
+        {
+            ServiceName = TabletServerServiceName;
+        }
     }
 }

--- a/src/Knet.Kudu.Client/Requests/KuduRpc.cs
+++ b/src/Knet.Kudu.Client/Requests/KuduRpc.cs
@@ -2,12 +2,7 @@ using System;
 using System.Buffers;
 using Google.Protobuf.Collections;
 using Knet.Kudu.Client.Connection;
-using Knet.Kudu.Client.Protobuf.Master;
-using Knet.Kudu.Client.Protobuf.Security;
-using Knet.Kudu.Client.Protobuf.Transactions;
-using Knet.Kudu.Client.Protobuf.Tserver;
 using Knet.Kudu.Client.Protocol;
-using Knet.Kudu.Client.Tablet;
 
 namespace Knet.Kudu.Client.Requests
 {
@@ -62,55 +57,5 @@ namespace Knet.Kudu.Client.Requests
     public abstract class KuduRpc<T> : KuduRpc
     {
         public T Output { get; protected set; }
-    }
-
-    internal abstract class KuduMasterRpc<T> : KuduRpc<T>
-    {
-        public MasterErrorPB Error { get; protected set; }
-
-        public KuduMasterRpc()
-        {
-            ServiceName = MasterServiceName;
-        }
-    }
-
-    internal abstract class KuduTxnRpc<T> : KuduRpc<T>
-    {
-        public TxnManagerErrorPB Error { get; protected set; }
-
-        public KuduTxnRpc()
-        {
-            ServiceName = TxnManagerServiceName;
-        }
-    }
-
-    internal abstract class KuduTabletRpc<T> : KuduRpc<T>
-    {
-        public long PropagatedTimestamp { get; set; } = KuduClient.NoTimestamp;
-
-        /// <summary>
-        /// Returns the partition key this RPC is for.
-        /// </summary>
-        public byte[] PartitionKey { get; init; }
-
-        public RemoteTablet Tablet { get; internal set; }
-
-        public ReplicaSelection ReplicaSelection { get; init; } = ReplicaSelection.LeaderOnly;
-
-        public bool NeedsAuthzToken { get; init; }
-
-        internal SignedTokenPB AuthzToken { get; set; }
-
-        /// <summary>
-        /// The table this RPC is for.
-        /// </summary>
-        public string TableId { get; init; }
-
-        public TabletServerErrorPB Error { get; protected set; }
-
-        public KuduTabletRpc()
-        {
-            ServiceName = TabletServerServiceName;
-        }
     }
 }

--- a/src/Knet.Kudu.Client/Requests/KuduTabletRpc.cs
+++ b/src/Knet.Kudu.Client/Requests/KuduTabletRpc.cs
@@ -1,0 +1,36 @@
+using Knet.Kudu.Client.Protobuf.Security;
+using Knet.Kudu.Client.Protobuf.Tserver;
+using Knet.Kudu.Client.Tablet;
+
+namespace Knet.Kudu.Client.Requests
+{
+    internal abstract class KuduTabletRpc<T> : KuduRpc<T>
+    {
+        public long PropagatedTimestamp { get; set; } = KuduClient.NoTimestamp;
+
+        /// <summary>
+        /// Returns the partition key this RPC is for.
+        /// </summary>
+        public byte[] PartitionKey { get; init; }
+
+        public RemoteTablet Tablet { get; internal set; }
+
+        public ReplicaSelection ReplicaSelection { get; init; } = ReplicaSelection.LeaderOnly;
+
+        public bool NeedsAuthzToken { get; init; }
+
+        internal SignedTokenPB AuthzToken { get; set; }
+
+        /// <summary>
+        /// The table this RPC is for.
+        /// </summary>
+        public string TableId { get; init; }
+
+        public TabletServerErrorPB Error { get; protected set; }
+
+        public KuduTabletRpc()
+        {
+            ServiceName = TabletServerServiceName;
+        }
+    }
+}

--- a/src/Knet.Kudu.Client/Requests/KuduTxnRpc.cs
+++ b/src/Knet.Kudu.Client/Requests/KuduTxnRpc.cs
@@ -1,0 +1,14 @@
+using Knet.Kudu.Client.Protobuf.Transactions;
+
+namespace Knet.Kudu.Client.Requests
+{
+    internal abstract class KuduTxnRpc<T> : KuduRpc<T>
+    {
+        public TxnManagerErrorPB Error { get; protected set; }
+
+        public KuduTxnRpc()
+        {
+            ServiceName = TxnManagerServiceName;
+        }
+    }
+}

--- a/src/Knet.Kudu.Client/Requests/ListTablesRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/ListTablesRequest.cs
@@ -5,18 +5,19 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class ListTablesRequest : KuduMasterRpc<ListTablesResponsePB>
+    internal sealed class ListTablesRequest : KuduMasterRpc<ListTablesResponsePB>
     {
-        private readonly ListTablesRequestPB _request;
+        private static readonly ListTablesRequestPB _noFilterRequest = new();
 
-        public override string MethodName => "ListTables";
+        private readonly ListTablesRequestPB _request;
 
         public ListTablesRequest(string nameFilter = null)
         {
-            _request = new ListTablesRequestPB
-            {
-                NameFilter = nameFilter
-            };
+            MethodName = "ListTables";
+
+            _request = nameFilter is null
+                ? _noFilterRequest
+                : new ListTablesRequestPB { NameFilter = nameFilter };
         }
 
         public override int CalculateSize() => _request.CalculateSize();

--- a/src/Knet.Kudu.Client/Requests/ListTabletServersRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/ListTabletServersRequest.cs
@@ -1,15 +1,19 @@
 using System.Buffers;
-using Google.Protobuf;
 using Knet.Kudu.Client.Protobuf.Master;
 using Knet.Kudu.Client.Protocol;
+using Knet.Kudu.Client.Util;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class ListTabletServersRequest : KuduMasterRpc<ListTabletServersResponsePB>
+    internal sealed class ListTabletServersRequest : KuduMasterRpc<ListTabletServersResponsePB>
     {
-        private static readonly byte[] _requestBytes = new ListTabletServersRequestPB().ToByteArray();
+        private static readonly byte[] _requestBytes = ProtobufHelper.ToByteArray(
+            new ListTabletServersRequestPB());
 
-        public override string MethodName => "ListTabletServers";
+        public ListTabletServersRequest()
+        {
+            MethodName = "ListTabletServers";
+        }
 
         public override int CalculateSize() => _requestBytes.Length;
 

--- a/src/Knet.Kudu.Client/Requests/ScanRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/ScanRequest.cs
@@ -11,7 +11,7 @@ using Knet.Kudu.Client.Tablet;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class ScanRequest : KuduTabletRpc<ScanResponse>, IDisposable
+    internal sealed class ScanRequest : KuduTabletRpc<ScanResponse>, IDisposable
     {
         private static readonly RepeatedField<uint> _columnPredicateRequiredFeature = new()
         {
@@ -38,6 +38,7 @@ namespace Knet.Kudu.Client.Requests
             _schema = schema;
             _isFaultTolerant = isFaultTolerant;
 
+            MethodName = "Scan";
             ReplicaSelection = replicaSelection;
             TableId = tableId;
             Tablet = tablet;
@@ -50,10 +51,6 @@ namespace Knet.Kudu.Client.Requests
                 RequiredFeatures = _columnPredicateRequiredFeature;
             }
         }
-
-        public override string MethodName => "Scan";
-
-        public override ReplicaSelection ReplicaSelection { get; }
 
         public void Dispose()
         {

--- a/src/Knet.Kudu.Client/Requests/SplitKeyRangeRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/SplitKeyRangeRequest.cs
@@ -5,7 +5,7 @@ using Knet.Kudu.Client.Protocol;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class SplitKeyRangeRequest : KuduTabletRpc<SplitKeyRangeResponsePB>
+    internal sealed class SplitKeyRangeRequest : KuduTabletRpc<SplitKeyRangeResponsePB>
     {
         private readonly SplitKeyRangeRequestPB _request;
 
@@ -27,12 +27,11 @@ namespace Knet.Kudu.Client.Requests
             if (endPrimaryKey != null && endPrimaryKey.Length > 0)
                 _request.StopPrimaryKey = UnsafeByteOperations.UnsafeWrap(endPrimaryKey);
 
+            MethodName = "SplitKeyRange";
             TableId = tableId;
             PartitionKey = partitionKey;
             NeedsAuthzToken = true;
         }
-
-        public override string MethodName => "SplitKeyRange";
 
         public override int CalculateSize()
         {

--- a/src/Knet.Kudu.Client/Requests/WriteRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/WriteRequest.cs
@@ -10,7 +10,11 @@ namespace Knet.Kudu.Client.Requests
     {
         private readonly WriteRequestPB _request;
 
-        public WriteRequest(WriteRequestPB request, string tableId, byte[] partitionKey)
+        public WriteRequest(
+            WriteRequestPB request,
+            string tableId,
+            byte[] partitionKey,
+            ExternalConsistencyMode externalConsistencyMode)
         {
             _request = request;
             MethodName = "Write";
@@ -18,6 +22,7 @@ namespace Knet.Kudu.Client.Requests
             PartitionKey = partitionKey;
             NeedsAuthzToken = true;
             IsRequestTracked = true;
+            ExternalConsistencyMode = externalConsistencyMode;
         }
 
         public override int CalculateSize()

--- a/src/Knet.Kudu.Client/Requests/WriteRequest.cs
+++ b/src/Knet.Kudu.Client/Requests/WriteRequest.cs
@@ -6,15 +6,14 @@ using Knet.Kudu.Client.Util;
 
 namespace Knet.Kudu.Client.Requests
 {
-    internal class WriteRequest : KuduTabletRpc<WriteResponsePB>
+    internal sealed class WriteRequest : KuduTabletRpc<WriteResponsePB>
     {
         private readonly WriteRequestPB _request;
-
-        public override string MethodName => "Write";
 
         public WriteRequest(WriteRequestPB request, string tableId, byte[] partitionKey)
         {
             _request = request;
+            MethodName = "Write";
             TableId = tableId;
             PartitionKey = partitionKey;
             NeedsAuthzToken = true;


### PR DESCRIPTION
This includes 2 functional changes:

 - Fix GetTablesAsync() without a name filter
 - Only set RPC PropagatedTimestamp for ExternalConsistencyMode.ClientPropagated