### PR TITLE
Remove special NaN encoding

### DIFF
--- a/src/Knet.Kudu.Client/Util/FloatingPointExtensions.cs
+++ b/src/Knet.Kudu.Client/Util/FloatingPointExtensions.cs
@@ -9,16 +9,16 @@ public static class FloatingPointExtensions
     /// <summary>
     /// Returns a representation of the specified floating-point value
     /// according to the IEEE 754 floating-point "single format" bit layout.
-    /// If the argument is NaN, the result is 0x7fc00000.
     /// </summary>
     /// <param name="value">A floating-point number.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int AsInt(this float value)
     {
-        // All NaN values are collapsed to a single "canonical" NaN value.
-        if (float.IsNaN(value))
-            return 0x7fc00000;
-
-        return SingleToInt32Bits(value);
+#if NETSTANDARD2_0
+        return Netstandard2Extensions.SingleToInt32Bits(value);
+#else
+        return BitConverter.SingleToInt32Bits(value);
+#endif
     }
 
     /// <summary>
@@ -40,15 +40,11 @@ public static class FloatingPointExtensions
     /// <summary>
     /// Returns a representation of the specified floating-point value
     /// according to the IEEE 754 floating-point "double format" bit layout.
-    /// If the argument is NaN, the result is 0x7ff8000000000000.
     /// </summary>
     /// <param name="value">A double precision floating-point number.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long AsLong(this double value)
     {
-        // All NaN values are collapsed to a single "canonical" NaN value.
-        if (double.IsNaN(value))
-            return 0x7ff8000000000000;
-
         return BitConverter.DoubleToInt64Bits(value);
     }
 
@@ -74,7 +70,7 @@ public static class FloatingPointExtensions
 #if NETCOREAPP3_1_OR_GREATER
         return MathF.BitIncrement(value);
 #else
-        int bits = SingleToInt32Bits(value);
+        int bits = value.AsInt();
 
         if ((bits & 0x7F800000) >= 0x7F800000)
         {
@@ -129,16 +125,6 @@ public static class FloatingPointExtensions
 
         bits += ((bits < 0) ? -1 : +1);
         return BitConverter.Int64BitsToDouble(bits);
-#endif
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int SingleToInt32Bits(float value)
-    {
-#if NETSTANDARD2_0
-        return Netstandard2Extensions.SingleToInt32Bits(value);
-#else
-        return BitConverter.SingleToInt32Bits(value);
 #endif
     }
 }


### PR DESCRIPTION
Don't collapse NaN values to a single "canonical" value.
This replaces the behavior of the Java client with that of the C++ client.