### PR TITLE
Improve getting raw/binary values from ResultSet

### DIFF
--- a/src/Knet.Kudu.Client/RowResult.cs
+++ b/src/Knet.Kudu.Client/RowResult.cs
@@ -145,18 +145,20 @@ public readonly struct RowResult
         _resultSet.GetNullableDecimal(columnIndex, _index);
 
     /// <summary>
-    /// Get the raw value of a fixed length data column.
+    /// Get the raw value of the given column.
     /// </summary>
     /// <param name="columnName">The column name.</param>
-    public ReadOnlySpan<byte> GetRawFixed(string columnName) =>
-        _resultSet.GetRawFixed(columnName, _index);
+    /// <returns>A zero-copy span of the raw value.</returns>
+    public ReadOnlySpan<byte> GetSpan(string columnName) =>
+        _resultSet.GetSpan(columnName, _index);
 
     /// <summary>
-    /// Get the raw value of a fixed length data column.
+    /// Get the raw value of the given column.
     /// </summary>
     /// <param name="columnIndex">The column index.</param>
-    public ReadOnlySpan<byte> GetRawFixed(int columnIndex) =>
-        _resultSet.GetRawFixed(columnIndex, _index);
+    /// <returns>A zero-copy span of the raw value.</returns>
+    public ReadOnlySpan<byte> GetSpan(int columnIndex) =>
+        _resultSet.GetSpan(columnIndex, _index);
 
     public string GetString(string columnName) =>
         _resultSet.GetString(columnName, _index);
@@ -170,11 +172,17 @@ public readonly struct RowResult
     public string? GetNullableString(int columnIndex) =>
         _resultSet.GetNullableString(columnIndex, _index);
 
-    public ReadOnlySpan<byte> GetBinary(string columnName) =>
+    public byte[] GetBinary(string columnName) =>
         _resultSet.GetBinary(columnName, _index);
 
-    public ReadOnlySpan<byte> GetBinary(int columnIndex) =>
+    public byte[] GetBinary(int columnIndex) =>
         _resultSet.GetBinary(columnIndex, _index);
+
+    public byte[]? GetNullableBinary(string columnName) =>
+        _resultSet.GetNullableBinary(columnName, _index);
+
+    public byte[]? GetNullableBinary(int columnIndex) =>
+        _resultSet.GetNullableBinary(columnIndex, _index);
 
     public bool IsNull(string columnName) =>
         _resultSet.IsNull(columnName, _index);
@@ -232,7 +240,7 @@ public readonly struct RowResult
                         stringBuilder.Append(GetString(i));
                         break;
                     case KuduType.Binary:
-                        stringBuilder.Append(BitConverter.ToString(GetBinary(i).ToArray()));
+                        stringBuilder.Append(BitConverter.ToString(GetBinary(i)));
                         break;
                     case KuduType.Float:
                         stringBuilder.Append(GetFloat(i));

--- a/test/Knet.Kudu.Client.FunctionalTests/KeyEncodingTests.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/KeyEncodingTests.cs
@@ -83,7 +83,7 @@ public class KeyEncodingTests : IAsyncLifetime
                 Assert.Equal(3, row.GetInt32("int32"));
                 Assert.Equal(4, row.GetInt64("int64"));
                 Assert.Equal("foo", row.GetString("string"));
-                Assert.Equal("bar".ToUtf8ByteArray(), row.GetBinary("binary").ToArray());
+                Assert.Equal("bar".ToUtf8ByteArray(), row.GetBinary("binary"));
                 Assert.Equal(6, row.GetInt64("timestamp"));
                 Assert.Equal(DecimalUtil.MaxUnscaledDecimal32, row.GetDecimal("decimal32"));
                 Assert.Equal(DecimalUtil.MaxUnscaledDecimal64, row.GetDecimal("decimal64"));

--- a/test/Knet.Kudu.Client.FunctionalTests/RowResultTests.cs
+++ b/test/Knet.Kudu.Client.FunctionalTests/RowResultTests.cs
@@ -44,7 +44,7 @@ public class RowResultTests
             {
                 Assert.Equal(currentRow, row.GetInt32("key"));
                 Assert.Equal(currentRow, row.GetNullableInt32("key"));
-                Assert.Equal(KuduEncoder.EncodeInt32(currentRow), row.GetRawFixed("key").ToArray());
+                Assert.Equal(KuduEncoder.EncodeInt32(currentRow), row.GetSpan("key").ToArray());
                 Assert.Equal(42, row.GetByte("int8"));
                 Assert.Equal((byte?)42, row.GetNullableByte("int8"));
                 Assert.Equal(42, row.GetSByte("int8"));
@@ -65,7 +65,8 @@ public class RowResultTests
                 Assert.Equal("fun with ütf\0", row.GetNullableString("string"));
                 Assert.Equal("árvíztűrő ", row.GetString("varchar"));
                 Assert.Equal("árvíztűrő ", row.GetNullableString("varchar"));
-                Assert.Equal(new byte[] { 0, 1, 2, 3, 4 }, row.GetBinary("binary").ToArray());
+                Assert.Equal(new byte[] { 0, 1, 2, 3, 4 }, row.GetBinary("binary"));
+                Assert.Equal(new byte[] { 0, 1, 2, 3, 4 }, row.GetSpan("binary").ToArray());
                 Assert.Equal(DateTime.Parse("8/19/2020 7:50 PM").ToUniversalTime(), row.GetDateTime("timestamp"));
                 Assert.Equal(DateTime.Parse("8/19/2020 7:50 PM").ToUniversalTime(), row.GetNullableDateTime("timestamp"));
                 Assert.Equal(DateTime.Parse("8/19/2020").ToUniversalTime().Date, row.GetDateTime("date"));
@@ -141,25 +142,28 @@ public class RowResultTests
                 Assert.Null(row.GetNullableDouble("double"));
                 Assert.Null(row.GetNullableString("string"));
                 Assert.Null(row.GetNullableString("varchar"));
-                Assert.Equal(0, row.GetBinary("binary").Length);
+                Assert.Null(row.GetNullableBinary("binary"));
                 Assert.Null(row.GetNullableDateTime("timestamp"));
                 Assert.Null(row.GetNullableDateTime("date"));
                 Assert.Null(row.GetNullableDecimal("decimal32"));
                 Assert.Null(row.GetNullableDecimal("decimal64"));
                 Assert.Null(row.GetNullableDecimal("decimal128"));
 
-                Assert.Equal(0, row.GetRawFixed("int8").Length);
-                Assert.Equal(0, row.GetRawFixed("int16").Length);
-                Assert.Equal(0, row.GetRawFixed("int32").Length);
-                Assert.Equal(0, row.GetRawFixed("int64").Length);
-                Assert.Equal(0, row.GetRawFixed("bool").Length);
-                Assert.Equal(0, row.GetRawFixed("float").Length);
-                Assert.Equal(0, row.GetRawFixed("double").Length);
-                Assert.Equal(0, row.GetRawFixed("timestamp").Length);
-                Assert.Equal(0, row.GetRawFixed("date").Length);
-                Assert.Equal(0, row.GetRawFixed("decimal32").Length);
-                Assert.Equal(0, row.GetRawFixed("decimal64").Length);
-                Assert.Equal(0, row.GetRawFixed("decimal128").Length);
+                Assert.Equal(0, row.GetSpan("int8").Length);
+                Assert.Equal(0, row.GetSpan("int16").Length);
+                Assert.Equal(0, row.GetSpan("int32").Length);
+                Assert.Equal(0, row.GetSpan("int64").Length);
+                Assert.Equal(0, row.GetSpan("bool").Length);
+                Assert.Equal(0, row.GetSpan("float").Length);
+                Assert.Equal(0, row.GetSpan("double").Length);
+                Assert.Equal(0, row.GetSpan("string").Length);
+                Assert.Equal(0, row.GetSpan("varchar").Length);
+                Assert.Equal(0, row.GetSpan("binary").Length);
+                Assert.Equal(0, row.GetSpan("timestamp").Length);
+                Assert.Equal(0, row.GetSpan("date").Length);
+                Assert.Equal(0, row.GetSpan("decimal32").Length);
+                Assert.Equal(0, row.GetSpan("decimal64").Length);
+                Assert.Equal(0, row.GetSpan("decimal128").Length);
                 currentRow++;
             }
         }
@@ -239,7 +243,7 @@ public class RowResultTests
 
                 Assert.Throws<ObjectDisposedException>(() => row.GetInt32("key"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetNullableInt32("key"));
-                Assert.Throws<ObjectDisposedException>(() => row.GetRawFixed("key"));
+                Assert.Throws<ObjectDisposedException>(() => row.GetSpan("key"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetByte("int8"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetNullableByte("int8"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetSByte("int8"));
@@ -260,7 +264,8 @@ public class RowResultTests
                 Assert.Throws<ObjectDisposedException>(() => row.GetNullableString("string"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetString("varchar"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetNullableString("varchar"));
-                Assert.Throws<ObjectDisposedException>(() => row.GetBinary("binary").ToArray());
+                Assert.Throws<ObjectDisposedException>(() => row.GetBinary("binary"));
+                Assert.Throws<ObjectDisposedException>(() => row.GetNullableBinary("binary"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetDateTime("timestamp"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetNullableDateTime("timestamp"));
                 Assert.Throws<ObjectDisposedException>(() => row.GetDateTime("date"));


### PR DESCRIPTION
Rename GetRawFixed() to GetSpan(), which now works for all data types.
GetBinary() now returns a byte[] and add GetNullableBinary() for consistency.