### PR TITLE
Make object mapper column matching more flexible

### DIFF
--- a/src/Knet.Kudu.Client/Mapper/ColumnNameMatcher.cs
+++ b/src/Knet.Kudu.Client/Mapper/ColumnNameMatcher.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+
+namespace Knet.Kudu.Client.Mapper;
+
+internal sealed class ColumnNameMatcher<T> where T : class
+{
+#if NETSTANDARD2_0
+    private static readonly StringComparer _columnComparer = StringComparer.Create(
+        CultureInfo.InvariantCulture,
+        ignoreCase: true);
+#else
+    private static readonly StringComparer _columnComparer = StringComparer.Create(
+        CultureInfo.InvariantCulture,
+        CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreSymbols);
+#endif
+
+    private readonly ILookup<string, T> _projectedColumns;
+    private readonly Func<T, string> _nameSelector;
+
+    public ColumnNameMatcher(IEnumerable<T> projectedColumns, Func<T, string> nameSelector)
+    {
+        _projectedColumns = projectedColumns.ToLookup(nameSelector, _columnComparer);
+        _nameSelector = nameSelector;
+    }
+
+    public bool TryGetColumn(string destinationName, [NotNullWhen(true)] out T? columnInfo)
+    {
+        var columns = _projectedColumns[destinationName];
+
+        T? caseInsensitiveMatch = null;
+        T? firstMatch = null;
+
+        // We could get multiple matches here, take the best one.
+        foreach (var column in columns)
+        {
+            var projectedName = _nameSelector(column);
+
+            if (StringComparer.Ordinal.Equals(destinationName, projectedName))
+            {
+                // Exact match.
+                columnInfo = column;
+                return true;
+            }
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(destinationName, projectedName))
+            {
+                if (caseInsensitiveMatch is null)
+                    caseInsensitiveMatch = column;
+            }
+            else
+            {
+                if (firstMatch is null)
+                    firstMatch = column;
+            }
+        }
+
+        if (caseInsensitiveMatch is not null)
+        {
+            columnInfo = caseInsensitiveMatch;
+            return true;
+        }
+
+        if (firstMatch is not null)
+        {
+            columnInfo = firstMatch;
+            return true;
+        }
+
+        columnInfo = null;
+        return false;
+    }
+}


### PR DESCRIPTION
This makes the column name to C# name matching more flexible. Symbol characters are now ignored when matching, so a Kudu column `First_Name` would match a C# property named `FirstName` (and vice versa).

When there are multiple matches the resolution order is,
1) An exact match
2) The first case insensitive match
3) The first match (ignoring symbols, whitespace, etc.)

This extended matching is not available on .NET Standard 2.0 due to a missing overload of StringComparer.Create().