### PR TITLE
Fix case where mapper could select the wrong delegate

### DIFF
--- a/src/Knet.Kudu.Client/ColumnSchema.cs
+++ b/src/Knet.Kudu.Client/ColumnSchema.cs
@@ -4,7 +4,7 @@ using Knet.Kudu.Client.Protobuf;
 
 namespace Knet.Kudu.Client;
 
-public class ColumnSchema : IEquatable<ColumnSchema>
+public sealed class ColumnSchema : IEquatable<ColumnSchema>
 {
     public string Name { get; }
 
@@ -71,7 +71,8 @@ public class ColumnSchema : IEquatable<ColumnSchema>
             Name == other.Name &&
             Type == other.Type &&
             IsKey == other.IsKey &&
-            IsNullable == other.IsNullable;
+            IsNullable == other.IsNullable &&
+            TypeAttributes == other.TypeAttributes;
     }
 
     public override bool Equals(object? obj) => Equals(obj as ColumnSchema);
@@ -86,6 +87,18 @@ public class ColumnSchema : IEquatable<ColumnSchema>
 
         return $"{Name} {Type}{typeAttributes}{nullable}{key}";
     }
+
+    public static bool operator ==(ColumnSchema? lhs, ColumnSchema? rhs)
+    {
+        if (lhs is null)
+        {
+            return rhs is null;
+        }
+
+        return lhs.Equals(rhs);
+    }
+
+    public static bool operator !=(ColumnSchema? lhs, ColumnSchema? rhs) => !(lhs == rhs);
 
     public static bool IsTypeFixedSize(KuduType type)
     {

--- a/src/Knet.Kudu.Client/ColumnTypeAttributes.cs
+++ b/src/Knet.Kudu.Client/ColumnTypeAttributes.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Knet.Kudu.Client;
 
-public class ColumnTypeAttributes
+public sealed class ColumnTypeAttributes : IEquatable<ColumnTypeAttributes>
 {
     public int? Precision { get; }
 
@@ -35,6 +37,36 @@ public class ColumnTypeAttributes
                 return "";
         }
     }
+
+    public bool Equals(ColumnTypeAttributes? other)
+    {
+        if (other is null)
+            return false;
+
+        if (ReferenceEquals(this, other))
+            return true;
+
+        return
+            Precision == other.Precision &&
+            Scale == other.Scale &&
+            Length == other.Length;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as ColumnTypeAttributes);
+
+    public override int GetHashCode() => HashCode.Combine(Precision, Scale, Length);
+
+    public static bool operator ==(ColumnTypeAttributes? lhs, ColumnTypeAttributes? rhs)
+    {
+        if (lhs is null)
+        {
+            return rhs is null;
+        }
+
+        return lhs.Equals(rhs);
+    }
+
+    public static bool operator !=(ColumnTypeAttributes? lhs, ColumnTypeAttributes? rhs) => !(lhs == rhs);
 
     public static ColumnTypeAttributes NewDecimalAttributes(
         int precision, int scale)

--- a/src/Knet.Kudu.Client/Mapper/DelegateCache.cs
+++ b/src/Knet.Kudu.Client/Mapper/DelegateCache.cs
@@ -49,8 +49,7 @@ internal sealed class DelegateCache
                 var columnX = columnsX[i];
                 var columnY = columnsY[i];
 
-                if (columnX.Type != columnY.Type ||
-                    columnX.IsNullable != columnY.IsNullable)
+                if (columnX != columnY)
                 {
                     return false;
                 }
@@ -66,8 +65,7 @@ internal sealed class DelegateCache
 
             foreach (var column in obj.Schema.Columns)
             {
-                hashcode.Add(column.Type);
-                hashcode.Add(column.IsNullable);
+                hashcode.Add(column);
             }
 
             return hashcode.ToHashCode();


### PR DESCRIPTION
Mapper delegate cache wasn't considering column name.