### PR TITLE
Use Span instead of Memory in some places

### DIFF
--- a/src/Knet.Kudu.Client/Connection/ISecurityContext.cs
+++ b/src/Knet.Kudu.Client/Connection/ISecurityContext.cs
@@ -39,7 +39,7 @@ public interface ISecurityContext
     /// Import data allowing this client to authenticate to the cluster.
     /// </summary>
     /// <param name="token">The authentication token.</param>
-    public void ImportAuthenticationCredentials(ReadOnlyMemory<byte> token);
+    public void ImportAuthenticationCredentials(ReadOnlySpan<byte> token);
 
     /// <summary>
     /// Mark the given CA cert (provided in DER form) as the trusted CA cert for the

--- a/src/Knet.Kudu.Client/Connection/SecurityContext.cs
+++ b/src/Knet.Kudu.Client/Connection/SecurityContext.cs
@@ -72,9 +72,9 @@ public sealed class SecurityContext : ISecurityContext
         return ProtobufHelper.ToByteArray(tokenPb);
     }
 
-    public void ImportAuthenticationCredentials(ReadOnlyMemory<byte> token)
+    public void ImportAuthenticationCredentials(ReadOnlySpan<byte> token)
     {
-        var tokenPb = AuthenticationCredentialsPB.Parser.ParseFrom(token.Span);
+        var tokenPb = AuthenticationCredentialsPB.Parser.ParseFrom(token);
         var caCertDers = tokenPb.CaCertDers.ToMemoryArray();
 
         lock (_lockObj)

--- a/src/Knet.Kudu.Client/KuduClient.cs
+++ b/src/Knet.Kudu.Client/KuduClient.cs
@@ -179,7 +179,7 @@ public sealed class KuduClient : IAsyncDisposable
     /// The authentication token provided by a prior call to
     /// <see cref="ExportAuthenticationCredentialsAsync(CancellationToken)"/>.
     /// </param>
-    public void ImportAuthenticationCredentials(ReadOnlyMemory<byte> token)
+    public void ImportAuthenticationCredentials(ReadOnlySpan<byte> token)
     {
         _securityContext.ImportAuthenticationCredentials(token);
     }
@@ -601,9 +601,9 @@ public sealed class KuduClient : IAsyncDisposable
     /// <param name="scanToken">The scan token to use.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     public ValueTask<KuduScannerBuilder> NewScanBuilderFromTokenAsync(
-        ReadOnlyMemory<byte> scanToken, CancellationToken cancellationToken = default)
+        ReadOnlySpan<byte> scanToken, CancellationToken cancellationToken = default)
     {
-        var scanTokenPb = KuduScanToken.DeserializePb(scanToken.Span);
+        var scanTokenPb = KuduScanToken.DeserializePb(scanToken);
         return NewScanBuilderFromTokenAsync(scanTokenPb, cancellationToken);
     }
 
@@ -728,9 +728,9 @@ public sealed class KuduClient : IAsyncDisposable
     /// </para>
     /// </summary>
     /// <param name="transactionToken">Serialized representation of a KuduTransaction.</param>
-    public KuduTransaction NewTransactionFromToken(ReadOnlyMemory<byte> transactionToken)
+    public KuduTransaction NewTransactionFromToken(ReadOnlySpan<byte> transactionToken)
     {
-        var tokenPb = TxnTokenPB.Parser.ParseFrom(transactionToken.Span);
+        var tokenPb = TxnTokenPB.Parser.ParseFrom(transactionToken);
         var txnId = tokenPb.TxnId;
         var keepaliveEnabled = tokenPb.HasEnableKeepalive && tokenPb.EnableKeepalive;
         var keepaliveInterval = keepaliveEnabled

--- a/src/Knet.Kudu.Client/KuduScanToken.cs
+++ b/src/Knet.Kudu.Client/KuduScanToken.cs
@@ -25,7 +25,7 @@ namespace Knet.Kudu.Client;
 /// <para>
 /// Scan tokens may be serialized using the <see cref="Serialize"/> method and
 /// deserialized back into a scanner using the
-/// <see cref="KuduClient.NewScanBuilderFromTokenAsync(ReadOnlyMemory{byte}, CancellationToken)"/>
+/// <see cref="KuduClient.NewScanBuilderFromTokenAsync(ReadOnlySpan{byte}, CancellationToken)"/>
 /// method. This allows use cases such as generating scan tokens in the planner
 /// component of a query engine, then sending the tokens to execution nodes based
 /// on locality, and then instantiating the scanners on those nodes.

--- a/src/Knet.Kudu.Client/KuduTransaction.cs
+++ b/src/Knet.Kudu.Client/KuduTransaction.cs
@@ -159,7 +159,7 @@ public sealed class KuduTransaction : IDisposable
     /// Kudu clients can perform operations to be a part of the same distributed
     /// transaction. The resulting string is referred to as a "transaction token"
     /// and it can be deserialized into a <see cref="KuduTransaction"/> via the
-    /// <see cref="KuduClient.NewTransactionFromToken(ReadOnlyMemory{byte})"/>.
+    /// <see cref="KuduClient.NewTransactionFromToken(ReadOnlySpan{byte})"/>.
     /// </para>
     /// </summary>
     public byte[] Serialize(KuduTransactionSerializationOptions options)
@@ -189,7 +189,7 @@ public sealed class KuduTransaction : IDisposable
     /// Kudu clients can perform operations to be a part of the same distributed
     /// transaction. The resulting string is referred to as a "transaction token"
     /// and it can be deserialized into a <see cref="KuduTransaction"/> via the
-    /// <see cref="KuduClient.NewTransactionFromToken(ReadOnlyMemory{byte})"/>.
+    /// <see cref="KuduClient.NewTransactionFromToken(ReadOnlySpan{byte})"/>.
     /// </para>
     /// </summary>
     public byte[] Serialize() => Serialize(_defaultSerializationOptions);


### PR DESCRIPTION
Synchronous methods should accept span instead of memory.