### PR TITLE
Don't cancel connect if requesting RPC is cancelled

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/examples/InsertLoadgen/bin/Debug/net6.0/InsertLoadgen.dll",
+            "program": "${workspaceFolder}/examples/InsertLoadgen/bin/Debug/net7.0/InsertLoadgen.dll",
             "args": [],
             "cwd": "${workspaceFolder}/examples/InsertLoadgen",
             "console": "internalConsole",


### PR DESCRIPTION
Don't cancel the connect task if the requesting RPC was cancelled. This prevents unnecessary connects if RPCs are configured with short timeouts. Only abort the connect task when the client is disposed.