### PR TITLE
Special case empty strings in FastHash

### DIFF
--- a/src/Knet.Kudu.Client/Util/FastHash.cs
+++ b/src/Knet.Kudu.Client/Util/FastHash.cs
@@ -10,6 +10,10 @@ namespace Knet.Kudu.Client.Util;
 /// </summary>
 public static class FastHash
 {
+    // Help distinguish zero-length objects like empty strings.
+    // These values must match those used by Apache Kudu.
+    private static ReadOnlySpan<byte> HashValEmpty => new byte[] { 0xee, 0x7e, 0xca, 0x7d };
+
     /// <summary>
     /// Compute 64-bit FastHash.
     /// </summary>
@@ -17,8 +21,13 @@ public static class FastHash
     /// <param name="seed">Seed to compute the hash.</param>
     public static ulong Hash64(ReadOnlySpan<byte> source, ulong seed)
     {
+        if (source.Length == 0)
+        {
+            source = HashValEmpty;
+        }
+
         uint length = (uint)source.Length;
-        ulong kMultiplier = 0x880355f21e6d1965UL;
+        const ulong kMultiplier = 0x880355f21e6d1965;
         ulong h = seed ^ (length * kMultiplier);
 
         ReadOnlySpan<ulong> data = MemoryMarshal.Cast<byte, ulong>(source);
@@ -71,7 +80,7 @@ public static class FastHash
     private static ulong FastHashMix(ulong h)
     {
         h ^= h >> 23;
-        h *= 0x2127599bf4325c37UL;
+        h *= 0x2127599bf4325c37;
         h ^= h >> 47;
         return h;
     }

--- a/test/Knet.Kudu.Client.Tests/FastHashTests.cs
+++ b/test/Knet.Kudu.Client.Tests/FastHashTests.cs
@@ -7,9 +7,11 @@ namespace Knet.Kudu.Client.Tests;
 public class FastHashTests
 {
     [Theory]
-    [InlineData("ab", 0, 17293172613997361769UL)]
-    [InlineData("abcdefg", 0, 10206404559164245992UL)]
-    [InlineData("quick brown fox", 42, 3757424404558187042UL)]
+    [InlineData("ab", 0, 17293172613997361769)]
+    [InlineData("abcdefg", 0, 10206404559164245992)]
+    [InlineData("quick brown fox", 42, 3757424404558187042)]
+    [InlineData("", 0, 4144680785095980158)]
+    [InlineData("", 1234, 3296774803014270295)]
     public void TestFastHash64(string data, ulong seed, ulong expectedHash)
     {
         ulong hash = FastHash.Hash64(data.ToUtf8ByteArray(), seed);
@@ -17,9 +19,11 @@ public class FastHashTests
     }
 
     [Theory]
-    [InlineData("ab", 0, 2564147595U)]
-    [InlineData("abcdefg", 0, 1497700618U)]
-    [InlineData("quick brown fox", 42, 1676541068U)]
+    [InlineData("ab", 0, 2564147595)]
+    [InlineData("abcdefg", 0, 1497700618)]
+    [InlineData("quick brown fox", 42, 1676541068)]
+    [InlineData("", 0, 3045300040)]
+    [InlineData("", 1234, 811548192)]
     public void TestFastHash32(string data, uint seed, uint expectedHash)
     {
         uint hash = FastHash.Hash32(data.ToUtf8ByteArray(), seed);


### PR DESCRIPTION
This is needed to match Kudu's fasthash implementation. Kudu's implementation also special cases null values, however upon testing I was unable to query null values using a bloom filter, so I omitted that special case.